### PR TITLE
Handle orphan LiveRC laps during import

### DIFF
--- a/docs/integrations/liverc-data-model.md
+++ b/docs/integrations/liverc-data-model.md
@@ -167,7 +167,9 @@ outside the Prisma schema until we widen storage.
 - Fixture-based contract tests must assert that the same LiveRC payload hashed
   twice produces identical `Lap.id` values.
 - Race results without a matching entry list row must be rejected (avoid orphan
-  laps).
+  laps). The import service skips those laps, increments the `skippedEntrantCount`
+  metric in its summary payload, and logs a warning so operators can reconcile
+  feed gaps with LiveRC.
 - Duplicate laps (same driver + lap number) must update the existing row rather
   than insert a second copy.
 

--- a/src/app/api/liverc/import/route.ts
+++ b/src/app/api/liverc/import/route.ts
@@ -78,6 +78,7 @@ export async function POST(request: Request) {
       entrantsProcessed: result.entrantsProcessed,
       lapsImported: result.lapsImported,
       skippedLapCount: result.skippedLapCount,
+      skippedEntrantCount: result.skippedEntrantCount,
       skippedOutlapCount: result.skippedOutlapCount,
     });
 

--- a/src/core/app/services/importLiveRc.ts
+++ b/src/core/app/services/importLiveRc.ts
@@ -75,6 +75,7 @@ export type LiveRcImportSummary = {
   entrantsProcessed: number;
   lapsImported: number;
   skippedLapCount: number;
+  skippedEntrantCount: number;
   skippedOutlapCount: number;
   sourceUrl: string;
   includeOutlaps: boolean;
@@ -159,6 +160,7 @@ export class LiveRcImportService {
     let entrantsProcessed = 0;
     let lapsImported = 0;
     let skippedLapCount = 0;
+    let skippedEntrantCount = 0;
     let skippedOutlapCount = 0;
 
     const groupedLaps = this.groupLapsByEntry(raceResult, includeOutlaps);
@@ -167,7 +169,19 @@ export class LiveRcImportService {
 
     for (const [entryId, laps] of groupedLaps.lapsByEntry.entries()) {
       const entry = entryMap.get(entryId);
-      if (entry?.withdrawn) {
+      if (!entry) {
+        skippedEntrantCount += 1;
+        skippedLapCount += laps.length;
+        console.warn(
+          '[LiveRcImportService] Skipping laps with no matching entry list row',
+          {
+            entryId,
+            lapsSkipped: laps.length,
+          },
+        );
+        continue;
+      }
+      if (entry.withdrawn) {
         continue;
       }
 
@@ -214,6 +228,7 @@ export class LiveRcImportService {
       entrantsProcessed,
       lapsImported,
       skippedLapCount,
+      skippedEntrantCount,
       skippedOutlapCount,
       sourceUrl: url,
       includeOutlaps,

--- a/tests/importLiveRc.test.ts
+++ b/tests/importLiveRc.test.ts
@@ -1,0 +1,181 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  LiveRcImportService,
+  type EntrantRepository,
+  type EventRepository,
+  type LapRepository,
+  type LiveRcClient,
+  type RaceClassRepository,
+  type SessionRepository,
+} from '../src/core/app';
+
+const now = new Date();
+
+test('orphan laps without entry list rows are skipped and reported', async () => {
+  const persistedEntrants: unknown[] = [];
+  const lapReplacements: unknown[] = [];
+
+  const event = {
+    id: 'event-1',
+    name: 'Test Event',
+    source: { eventId: 'event-1', url: 'https://liverc.com/results/event' },
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const raceClass = {
+    id: 'class-1',
+    eventId: event.id,
+    name: 'Test Class',
+    classCode: 'TC',
+    sourceUrl: 'https://liverc.com/results/event/class',
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const session = {
+    id: 'session-1',
+    eventId: event.id,
+    raceClassId: raceClass.id,
+    name: 'Test Race',
+    source: {
+      sessionId: 'round-1:race-1',
+      url: 'https://liverc.com/results/event/class/round/race',
+    },
+    scheduledStart: null,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  const liveRcClient: LiveRcClient = {
+    async fetchEntryList() {
+      return {
+        eventId: 'event-remote',
+        classId: 'class-remote',
+        entries: [],
+      };
+    },
+    async fetchRaceResult() {
+      return {
+        eventId: 'event-remote',
+        classId: 'class-remote',
+        raceId: 'race-remote',
+        raceName: 'Remote Race',
+        laps: [
+          {
+            entryId: 'missing-entry',
+            driverName: 'Mystery Driver',
+            lapNumber: 1,
+            lapTimeSeconds: 40.123,
+          },
+        ],
+      };
+    },
+  };
+
+  const eventRepository: EventRepository = {
+    async getById() {
+      return null;
+    },
+    async findBySourceId() {
+      return null;
+    },
+    async findBySourceUrl() {
+      return null;
+    },
+    async upsertBySource() {
+      return event;
+    },
+  };
+
+  const raceClassRepository: RaceClassRepository = {
+    async findByEventAndCode() {
+      return null;
+    },
+    async upsertBySource() {
+      return raceClass;
+    },
+  };
+
+  const sessionRepository: SessionRepository = {
+    async getById() {
+      return null;
+    },
+    async findBySourceId() {
+      return null;
+    },
+    async findBySourceUrl() {
+      return null;
+    },
+    async listByEvent() {
+      return [];
+    },
+    async listByRaceClass() {
+      return [];
+    },
+    async upsertBySource() {
+      return session;
+    },
+  };
+
+  const entrantRepository: EntrantRepository = {
+    async getById() {
+      return null;
+    },
+    async findBySourceEntrantId() {
+      return null;
+    },
+    async listBySession() {
+      return [];
+    },
+    async upsertBySource(input) {
+      persistedEntrants.push(input);
+      return {
+        id: `entrant-${persistedEntrants.length}`,
+        eventId: input.eventId,
+        raceClassId: input.raceClassId,
+        sessionId: input.sessionId,
+        displayName: input.displayName,
+        carNumber: input.carNumber ?? null,
+        source: {
+          entrantId: input.sourceEntrantId ?? null,
+          transponderId: input.sourceTransponderId ?? null,
+        },
+        createdAt: now,
+        updatedAt: now,
+      };
+    },
+  };
+
+  const lapRepository: LapRepository = {
+    async listByEntrant() {
+      return [];
+    },
+    async replaceForEntrant(entrantId, sessionId, laps) {
+      lapReplacements.push({ entrantId, sessionId, laps });
+    },
+  };
+
+  const service = new LiveRcImportService({
+    liveRcClient,
+    eventRepository,
+    raceClassRepository,
+    sessionRepository,
+    entrantRepository,
+    lapRepository,
+  });
+
+  const summary = await service.importFromUrl(
+    'https://liverc.com/results/event/class/round/race',
+  );
+
+  assert.equal(summary.entrantsProcessed, 0);
+  assert.equal(summary.lapsImported, 0);
+  assert.equal(summary.skippedEntrantCount, 1);
+  assert.equal(summary.skippedLapCount, 1);
+  assert.equal(summary.skippedOutlapCount, 0);
+  assert.equal(persistedEntrants.length, 0);
+  assert.equal(lapReplacements.length, 0);
+});

--- a/tests/lap-summary-dependencies.test.ts
+++ b/tests/lap-summary-dependencies.test.ts
@@ -20,6 +20,10 @@ class InMemoryEntrantRepository implements EntrantRepository {
   async listBySession(sessionId: string) {
     return Array.from(this.entrants.values()).filter((entrant) => entrant.sessionId === sessionId);
   }
+
+  async upsertBySource(): Promise<Entrant> {
+    throw new Error('InMemoryEntrantRepository.upsertBySource is not implemented for this test');
+  }
 }
 
 const withDatabaseUrl = async (value: string | undefined, fn: () => Promise<void>) => {


### PR DESCRIPTION
## Summary
- skip LiveRC laps whose entry list row is missing, log the data error, and track a skipped entrant counter in the summary
- surface the new counter in the LiveRC import API response and document the orphan-lap behaviour for operators
- add an orphan-lap regression test and satisfy repository contracts in test doubles

## Testing
- npx tsx --test tests/importLiveRc.test.ts
- npm run test:seo
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68de012887e883219b6001b4a41d94e6