### PR TITLE
docs: reference LiveRC deep code review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,3 +118,7 @@ Every PR must state: **what/why**, design/UX compliance, checks (`typecheck`/`li
 - When adding a new role doc, mirror the existing naming convention (`kebab-case-role.md`) and link it from any relevant onboarding or README sections.
 - Current roles covered: DevOps Platform Engineer, Documentation Knowledge Steward, Next.js Front-end Engineer, Observability & Incident Response Lead, Prisma/PostgreSQL Backend Engineer, Quality Automation Engineer, and TypeScript Domain Engineer.
 - Keep these files focused on responsibilities, key workflows, and references—avoid project-specific chatter that will rot quickly.
+
+## 14) Deep review archives (`docs/reviews/*`)
+- Before touching critical flows, check the relevant deep review in `docs/reviews/` for historical context and known pitfalls.
+- The LiveRC ingestion pipeline has an in-depth audit at [`docs/reviews/2024-10-07-deep-code-review.md`](docs/reviews/2024-10-07-deep-code-review.md); consult it alongside this guide when working on those areas.

--- a/docs/reviews/2024-10-07-deep-code-review.md
+++ b/docs/reviews/2024-10-07-deep-code-review.md
@@ -18,3 +18,7 @@
 - Teach the API route to detect `LiveRcHttpError` and respond with its status/code payload.
 - Harden `LiveRcImportService` to fail fast when an entry list row is missing for a lap entry; logging the upstream identifiers will help debugging LiveRC quirks.
 - Replace `new Date(...)` parsing with a safe parser (e.g. `DateTime.fromSQL` via `luxon`) or discard timestamps that lack timezone context.
+
+---
+
+_Maintenance note:_ This review is treated as a living reference for the LiveRC ingestion stack. Keep it in sync with major architecture changes and cross-link updates back in [`AGENTS.md`](../../AGENTS.md) so future reviewers can discover the latest context quickly.


### PR DESCRIPTION
## Summary
- add a documentation section in AGENTS.md pointing contributors to the deep review archives under docs/reviews
- highlight the LiveRC ingestion deep code review as required reading when touching that surface area
- document maintenance expectations inside the 2024-10-07 review and cross-link back to AGENTS.md

## Testing
- npx --yes markdown-link-check AGENTS.md *(fails: npm registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de012ad8ac83219d0e8b51c2c0473e