### PR TITLE
Add README index for guardrail and ingestion docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,15 +246,27 @@ Use **semantic colour tokens** instead of hard-coding hex in components.
 ## Docs & ADRs
 - Keep `/.env.example` authoritative and in sync with the Codex Environment.
 - Author **ADRs** under `docs/adr/ADR-YYYYMMDD-title.md` when a choice is **cross-cutting**, **breaking**, **costly to reverse**, or **security/ops-critical** (include context, options, decision, consequences, follow-ups).
-- Keep the LiveRC ingestion contract at [`docs/integrations/liverc-data-model.md`](docs/integrations/liverc-data-model.md) up to date whenever schema or connector rules change.
+
+### Guardrails & environment references
+- [`docs/guardrails/product-guardrails.md`](docs/guardrails/product-guardrails.md) — MVP scope, success measures, and non-goals.
+- [`docs/guardrails/qa-network-access.md`](docs/guardrails/qa-network-access.md) — sandbox networking limits for QA validation.
+
+### LiveRC ingestion references
+- [`docs/integrations/liverc-data-model.md`](docs/integrations/liverc-data-model.md) — contract that all LiveRC connectors must honour.
+- [`docs/integrations/liverc-import-api.md`](docs/integrations/liverc-import-api.md) — `/api/liverc/import` request/response envelopes and error mapping.
+- [`src/core/app/README.md`](src/core/app/README.md) — service pipeline that orchestrates ingestion work.
+
+### Roles, reviews, and audits
 - Consult the **role playbooks** in [`docs/roles/`](docs/roles) whenever you are acting in one of those capacities; they capture process and decision context that should shape design choices for that hat.
 - Review the **deep code review archives** in [`docs/reviews/`](docs/reviews) before modifying the covered flows so that new changes preserve the documented learnings.
-- Forthcoming docs (placeholders for now):
-  - `docs/design-principles.md` — layering exceptions, server/client rules, ADR policy
-  - `docs/ux-principles.md` — layout, spacing, accessibility, token map
-  - `docs/domain-model.md` — entities/relations/invariants  
-  - `docs/agents/**` — policies, prompts, checklists (auth-ux, auth-security, accessibility, telemetry)  
-  - `docs/roles/**` — responsibilities & handoffs
+- [`docs/reviews/2025-02-14-markdown-audit.md`](docs/reviews/2025-02-14-markdown-audit.md) tracks the latest doc freshness review and suggested follow-ups.
+
+### Forthcoming docs (placeholders)
+- `docs/design-principles.md` — layering exceptions, server/client rules, ADR policy
+- `docs/ux-principles.md` — layout, spacing, accessibility, token map
+- `docs/domain-model.md` — entities/relations/invariants
+- `docs/agents/**` — policies, prompts, checklists (auth-ux, auth-security, accessibility, telemetry)
+- `docs/roles/**` — responsibilities & handoffs
 
 ---
 


### PR DESCRIPTION
## Summary
- extend the Docs & ADRs section to link the guardrail, integration, and ingestion references already in the repo
- add a pointer to the latest markdown audit so contributors can track doc follow-ups

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68df2760208883219a3ed867c823aefd