### PR TITLE
feat: proxy entry list responses via dev LiveRC route

### DIFF
--- a/src/app/api/dev/liverc/results/[...slug]/route.ts
+++ b/src/app/api/dev/liverc/results/[...slug]/route.ts
@@ -1,0 +1,136 @@
+import { randomUUID } from 'node:crypto';
+
+import { NextResponse } from 'next/server';
+
+const baseHeaders = {
+  'Cache-Control': 'no-store',
+  'X-Robots-Tag': 'noindex, nofollow',
+};
+
+const proxyParamValues = new Set(['1', 'true', 'yes']);
+
+const isValidPathSegment = (segment: string | undefined) =>
+  typeof segment === 'string' && segment.trim().length > 0 && !segment.includes('/');
+
+const isValidSlug = (slug: string[]) => {
+  if (!Array.isArray(slug)) {
+    return false;
+  }
+
+  if (slug.length === 3) {
+    const [eventSlug, classSlug, fileName] = slug;
+    return (
+      isValidPathSegment(eventSlug) &&
+      isValidPathSegment(classSlug) &&
+      fileName === 'entry-list.json'
+    );
+  }
+
+  if (slug.length === 4) {
+    const [eventSlug, classSlug, roundSlug, fileName] = slug;
+    return (
+      isValidPathSegment(eventSlug) &&
+      isValidPathSegment(classSlug) &&
+      isValidPathSegment(roundSlug) &&
+      typeof fileName === 'string' &&
+      fileName.endsWith('.json') &&
+      fileName.trim().length > 0
+    );
+  }
+
+  return false;
+};
+
+const jsonResponse = (status: number, payload: unknown, requestId: string) =>
+  NextResponse.json(payload, {
+    status,
+    headers: {
+      ...baseHeaders,
+      'x-request-id': requestId,
+    },
+  });
+
+type RouteContext = {
+  params: {
+    slug?: string[];
+  };
+};
+
+export async function GET(request: Request, context: RouteContext) {
+  const requestId = request.headers.get('x-request-id') ?? randomUUID();
+  const slug = context.params.slug ?? [];
+
+  if (!isValidSlug(slug)) {
+    console.warn('liverc.dev.invalid_slug', { requestId, slug });
+
+    return jsonResponse(
+      400,
+      {
+        error: {
+          code: 'INVALID_LIVERC_PATH',
+          message: 'LiveRC proxy requires an event, class, and JSON resource path.',
+          details: { slug },
+        },
+        requestId,
+      },
+      requestId,
+    );
+  }
+
+  const url = new URL(request.url);
+  const proxyParam = url.searchParams.get('proxy');
+
+  if (!proxyParam || !proxyParamValues.has(proxyParam.toLowerCase())) {
+    console.warn('liverc.dev.proxy_disabled', { requestId, slug });
+
+    return jsonResponse(
+      400,
+      {
+        error: {
+          code: 'PROXY_DISABLED',
+          message: 'LiveRC proxy requires ?proxy=1 in development.',
+        },
+        requestId,
+      },
+      requestId,
+    );
+  }
+
+  const upstreamUrl = `https://liverc.com/results/${slug
+    .map((segment) => encodeURIComponent(segment))
+    .join('/')}`;
+
+  try {
+    const upstreamResponse = await fetch(upstreamUrl, {
+      headers: {
+        Accept: 'application/json',
+        'User-Agent': 'MyRaceEngineerDevProxy/1.0',
+      },
+      cache: 'no-store',
+    });
+
+    const headers = new Headers(upstreamResponse.headers);
+    headers.set('cache-control', baseHeaders['Cache-Control']);
+    headers.set('x-robots-tag', baseHeaders['X-Robots-Tag']);
+    headers.set('x-request-id', requestId);
+
+    return new Response(upstreamResponse.body, {
+      status: upstreamResponse.status,
+      headers,
+    });
+  } catch (error) {
+    console.error('liverc.dev.proxy_failure', { requestId, slug, error });
+
+    return jsonResponse(
+      502,
+      {
+        error: {
+          code: 'LIVERC_PROXY_ERROR',
+          message: 'Failed to proxy LiveRC response.',
+        },
+        requestId,
+      },
+      requestId,
+    );
+  }
+}

--- a/tests/dev-liverc-results-proxy-route.test.ts
+++ b/tests/dev-liverc-results-proxy-route.test.ts
@@ -1,0 +1,93 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { GET } from '../src/app/api/dev/liverc/results/[...slug]/route';
+
+type FetchCall = {
+  url: string;
+  init: RequestInit | undefined;
+};
+
+const withPatchedFetch = async (
+  stub: (input: RequestInfo, init?: RequestInit) => Promise<Response>,
+  run: (calls: FetchCall[]) => Promise<void>,
+) => {
+  const calls: FetchCall[] = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (input: RequestInfo, init?: RequestInit) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    calls.push({ url, init });
+    return stub(input, init);
+  };
+
+  try {
+    await run(calls);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+};
+
+test('GET /api/dev/liverc/results proxies race result requests when proxy flag enabled', async () => {
+  await withPatchedFetch(async () => {
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }, async (calls) => {
+    const request = new Request(
+      'http://localhost/api/dev/liverc/results/sample-event/sample-class/round-1/a-main.json?proxy=1',
+      {
+        headers: { 'x-request-id': 'test-race-result' },
+      },
+    );
+
+    const response = await GET(request, {
+      params: {
+        slug: ['sample-event', 'sample-class', 'round-1', 'a-main.json'],
+      },
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(calls.length, 1);
+    assert.equal(
+      calls[0]?.url,
+      'https://liverc.com/results/sample-event/sample-class/round-1/a-main.json',
+    );
+
+    const payload = (await response.json()) as { ok: boolean };
+    assert.deepEqual(payload, { ok: true });
+  });
+});
+
+test('GET /api/dev/liverc/results proxies entry list requests when proxy flag enabled', async () => {
+  await withPatchedFetch(async () => {
+    return new Response(JSON.stringify({ entries: [] }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  }, async (calls) => {
+    const request = new Request(
+      'http://localhost/api/dev/liverc/results/sample-event/sample-class/entry-list.json?proxy=1',
+      {
+        headers: { 'x-request-id': 'test-entry-list' },
+      },
+    );
+
+    const response = await GET(request, {
+      params: {
+        slug: ['sample-event', 'sample-class', 'entry-list.json'],
+      },
+    });
+
+    assert.equal(response.status, 200);
+    assert.equal(calls.length, 1);
+    assert.equal(
+      calls[0]?.url,
+      'https://liverc.com/results/sample-event/sample-class/entry-list.json',
+    );
+
+    const payload = (await response.json()) as { entries: unknown[] };
+    assert.deepEqual(payload, { entries: [] });
+  });
+});


### PR DESCRIPTION
## Summary
- allow the dev LiveRC proxy route to accept entry list JSON paths alongside race result slugs
- add coverage that confirms both entry list and race result requests succeed when the proxy flag is supplied

## Testing
- npx tsx --test tests/dev-liverc-results-proxy-route.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68df27ed151c8321bcda80d44ef25561