### PR TITLE
docs: correct repo references and tidy guardrail guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 # My Race Engineer (MRE) — Agents Guide (Codex & other AI contributors)
-**Repo:** `JaysonBrenton/The-Pace-Tracer`  
+**Repo:** `JaysonBrenton/My-Race-Engineer`
 **Updated:** 2025-09-29  
 **Purpose:** Guardrails for automated/semi-automated contributions. Deep details will live in `docs/**`.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 **The one-stop lap logic shop.**  
 Next.js (App Router) + TypeScript + Prisma/PostgreSQL with clean layering, strict linting, structured error handling, and CI-friendly conventions.
 
-> Repo: `JaysonBrenton/The-Pace-Tracer` • Default port: **:3001** (binds `0.0.0.0`) • Timezone: **Australia/Sydney**
+> Repo: `JaysonBrenton/My-Race-Engineer` • Default port: **:3001** (binds `0.0.0.0`) • Timezone: **Australia/Sydney**
 
 ---
 
@@ -69,8 +69,8 @@ prisma/
 
 ### 1) Get the code
 ~~~
-git clone https://github.com/JaysonBrenton/The-Pace-Tracer.git
-cd The-Pace-Tracer
+git clone https://github.com/JaysonBrenton/My-Race-Engineer.git
+cd My-Race-Engineer
 ~~~
 
 ### 2) Start Postgres (choose one)

--- a/docs/guardrails/product-guardrails.md
+++ b/docs/guardrails/product-guardrails.md
@@ -31,9 +31,11 @@ Success is measured by the time it takes a driver to understand: *How fast am I?
 4. **Insightful visualisations**
    - Use tokenised chart components (ApexCharts or equivalent) that respect the design token system.
    - Provide distribution/consistency indicators (e.g., box plots, histograms, sparklines).
-   - Highlight anomalies such as slow or missing laps. The definition of a slow lap is;
-
-A slow lap is a lap whose time is meaningfully higher than the driver’s normal pace for that stint/session—i.e., an outlier versus their clean-lap baseline. Rule of thumb: flag it if the lap is >110–115% of median, > median + 2σ, or > +1.5–2.0 s (class-dependent). Common causes: bobble/crash and marshal pickup, traffic, bad landing over jumps, off-line mistakes, pit/stop-go, or short-term mechanical/tyre/battery issues.
+   - Highlight anomalies such as slow or missing laps. Treat a lap as "slow" when one or more of the following rules apply:
+     - Lap time exceeds **110–115%** of the driver’s median for the stint/session.
+     - Lap time is greater than **median + 2σ** for the driver.
+     - Lap time is more than **1.5–2.0 seconds** slower than the driver’s clean-lap baseline (class-dependent).
+   - Call out common causes (bobble/crash and marshal pickup, traffic, poor landings, off-line mistakes, pit/stop-go penalties, mechanical/tyre/battery issues) alongside the flagged laps so operators can triage quickly.
 
 5. **Filtering & focus tools**
    - Toggle visibility of outlaps/inlaps.

--- a/docs/reviews/2025-03-07-deep-code-review.md
+++ b/docs/reviews/2025-03-07-deep-code-review.md
@@ -6,7 +6,6 @@
 - Documentation sweep across `README.md`, `docs/**`, and other tracked Markdown assets (excluding vendored `node_modules/**`).
 
 ## Critical issues
-odex/perform-deep-code-review-and-markdown-audit
 1. **Race URL handling contradicts the documented `.json` contract (blocking imports).** ✅ *Resolved 2025-03-07*
    - Parsed race slugs now trim trailing `.json` tokens before building upstream URLs, so callers can submit either the human-facing results URL or the raw JSON endpoint without triggering double extensions.【F:src/core/app/services/importLiveRc.ts†L276-L316】
    - The dev LiveRC proxy accepts both `entry-list` and `entry-list.json`, normalises the final segment, and mirrors the ingestion rules to avoid future drift.【F:src/app/api/dev/liverc/results/[...slug]/route.ts†L12-L111】
@@ -27,7 +26,6 @@ odex/perform-deep-code-review-and-markdown-audit
 ## Documentation audit
 | File | Status | Notes |
 | --- | --- | --- |
-codex/perform-deep-code-review-and-markdown-audit
 | `README.md` | ✅ Updated | Duplicate "Forthcoming docs" sections and stray branch slugs removed; doc index now reflects the maintained references only.【F:README.md†L263-L297】 |
 | `src/core/app/README.md` | ✅ Updated | Documents the shipped LiveRC import service instead of a future pipeline, including persistence rules and test strategy.【F:src/core/app/README.md†L1-L52】 |
 | `docs/reviews/2024-10-07-deep-code-review.md` | ✅ Historical | Annotated with resolution dates so readers know the flagged issues have been addressed.【F:docs/reviews/2024-10-07-deep-code-review.md†L9-L34】 |


### PR DESCRIPTION
## Summary
- update repository references in the agent and contributor READMEs to point to JaysonBrenton/My-Race-Engineer
- clean the 2025-03-07 deep code review record by removing stray text left by previous automation
- clarify the slow-lap heuristics in the product guardrails with a structured checklist for anomalies

## Testing
- not run (docs-only change)

------
https://chatgpt.com/codex/tasks/task_e_68df3ca162f48321b0b3a344fa475749