### PR TITLE
Add LiveRC URL parser and update import service validation

### DIFF
--- a/src/core/liverc/urlParser.test.ts
+++ b/src/core/liverc/urlParser.test.ts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  LiveRcUrlInvalidReasons,
+  parseLiveRcUrl,
+  type LiveRcJsonUrlParseResult,
+  type LiveRcInvalidUrlParseResult,
+} from './urlParser';
+
+test('parseLiveRcUrl recognises valid JSON results URLs with four segments', () => {
+  const url = 'https://liverc.com/results/SUMMER SERIES/2WD Buggy/Round 3/A Main.json';
+  const result = parseLiveRcUrl(url) as LiveRcJsonUrlParseResult;
+
+  assert.equal(result.type, 'json');
+  assert.deepEqual(result.slugs, ['summer-series', '2wd-buggy', 'round-3', 'a-main']);
+  assert.equal(result.canonicalJsonPath, '/results/summer-series/2wd-buggy/round-3/a-main.json');
+});
+
+test('parseLiveRcUrl infers canonical path when JSON extension is omitted', () => {
+  const url = 'https://liverc.com/results/Winter Showdown/Expert 4WD/Round 1/Main Event';
+  const result = parseLiveRcUrl(url) as LiveRcJsonUrlParseResult;
+
+  assert.equal(result.type, 'json');
+  assert.deepEqual(result.slugs, ['winter-showdown', 'expert-4wd', 'round-1', 'main-event']);
+  assert.equal(result.canonicalJsonPath, '/results/winter-showdown/expert-4wd/round-1/main-event.json');
+});
+
+test('parseLiveRcUrl flags legacy HTML results URLs', () => {
+  const url = 'https://liverc.com/?p=view_race_result&id=12345';
+  const result = parseLiveRcUrl(url);
+
+  assert.equal(result.type, 'html');
+});
+
+test('parseLiveRcUrl reports invalid URLs with descriptive reasons', () => {
+  const invalidResults: Array<{ input: string; reason: LiveRcInvalidUrlParseResult['reasonIfInvalid'] }> = [
+    { input: 'not-a-url', reason: LiveRcUrlInvalidReasons.INVALID_ABSOLUTE_URL },
+    {
+      input: 'https://liverc.com/results/event/class/round',
+      reason: LiveRcUrlInvalidReasons.INCOMPLETE_RESULTS_SEGMENTS,
+    },
+    {
+      input: 'https://liverc.com/results/event/class/round/race/extra',
+      reason: LiveRcUrlInvalidReasons.EXTRA_SEGMENTS,
+    },
+    {
+      input: 'https://liverc.com/somewhere-else',
+      reason: LiveRcUrlInvalidReasons.INVALID_RESULTS_PATH,
+    },
+  ];
+
+  for (const { input, reason } of invalidResults) {
+    const result = parseLiveRcUrl(input);
+    assert.equal(result.type, 'invalid');
+    assert.equal(result.reasonIfInvalid, reason);
+  }
+});

--- a/src/core/liverc/urlParser.ts
+++ b/src/core/liverc/urlParser.ts
@@ -1,0 +1,122 @@
+export const LiveRcUrlInvalidReasons = {
+  INVALID_ABSOLUTE_URL: 'LiveRC import requires an absolute URL.',
+  INVALID_RESULTS_PATH: 'LiveRC URL must point to a JSON results endpoint under /results/.',
+  INCOMPLETE_RESULTS_SEGMENTS: 'LiveRC results URL must include event, class, round, and race segments.',
+  EXTRA_SEGMENTS: 'LiveRC results URL must not include extra path segments after the race slug.',
+  EMPTY_SEGMENT: 'LiveRC results URL must not include empty path segments.',
+  EMPTY_SLUG: 'LiveRC results URL contains a segment that resolves to an empty slug.',
+} as const;
+
+export type LiveRcUrlInvalidReason = (typeof LiveRcUrlInvalidReasons)[keyof typeof LiveRcUrlInvalidReasons];
+
+export type LiveRcJsonUrlParseResult = {
+  type: 'json';
+  slugs: [string, string, string, string];
+  canonicalJsonPath: string;
+};
+
+export type LiveRcHtmlUrlParseResult = {
+  type: 'html';
+};
+
+export type LiveRcInvalidUrlParseResult = {
+  type: 'invalid';
+  reasonIfInvalid: LiveRcUrlInvalidReason;
+};
+
+export type LiveRcUrlParseResult =
+  | LiveRcJsonUrlParseResult
+  | LiveRcHtmlUrlParseResult
+  | LiveRcInvalidUrlParseResult;
+
+const normaliseSegment = (segment: string, { isRaceSegment }: { isRaceSegment: boolean }) => {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(segment);
+  } catch {
+    return { ok: false as const, reason: LiveRcUrlInvalidReasons.INVALID_ABSOLUTE_URL };
+  }
+
+  const trimmed = decoded.trim();
+  if (!trimmed) {
+    return { ok: false as const, reason: LiveRcUrlInvalidReasons.EMPTY_SEGMENT };
+  }
+
+  let slug = trimmed.replace(/\s+/g, '-');
+  slug = slug.replace(/-+/g, '-');
+  slug = slug.replace(/^[-]+|[-]+$/g, '');
+
+  if (isRaceSegment) {
+    slug = slug.replace(/\.json$/i, '');
+  }
+
+  slug = slug.toLowerCase();
+
+  if (!slug) {
+    return { ok: false as const, reason: LiveRcUrlInvalidReasons.EMPTY_SLUG };
+  }
+
+  return { ok: true as const, slug };
+};
+
+export const parseLiveRcUrl = (input: string): LiveRcUrlParseResult => {
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(input);
+  } catch {
+    return { type: 'invalid', reasonIfInvalid: LiveRcUrlInvalidReasons.INVALID_ABSOLUTE_URL };
+  }
+
+  const legacyPage = parsedUrl.searchParams.get('p');
+  if (legacyPage?.toLowerCase() === 'view_race_result') {
+    const id = parsedUrl.searchParams.get('id');
+    if (id && id.trim().length > 0) {
+      return { type: 'html' };
+    }
+  }
+
+  const pathSegments = parsedUrl.pathname.split('/').filter(Boolean);
+  const resultsIndex = pathSegments.findIndex((segment) => segment.toLowerCase() === 'results');
+
+  if (resultsIndex === -1) {
+    return { type: 'invalid', reasonIfInvalid: LiveRcUrlInvalidReasons.INVALID_RESULTS_PATH };
+  }
+
+  const afterResults = pathSegments.slice(resultsIndex + 1);
+
+  if (afterResults.length === 0) {
+    return { type: 'invalid', reasonIfInvalid: LiveRcUrlInvalidReasons.INCOMPLETE_RESULTS_SEGMENTS };
+  }
+
+  if (afterResults.length < 4) {
+    return { type: 'invalid', reasonIfInvalid: LiveRcUrlInvalidReasons.INCOMPLETE_RESULTS_SEGMENTS };
+  }
+
+  if (afterResults.length > 4) {
+    return { type: 'invalid', reasonIfInvalid: LiveRcUrlInvalidReasons.EXTRA_SEGMENTS };
+  }
+
+  const normalisedSlugs: string[] = [];
+  for (let index = 0; index < afterResults.length; index += 1) {
+    const segment = afterResults[index];
+    const normalised = normaliseSegment(segment, { isRaceSegment: index === afterResults.length - 1 });
+
+    if (!normalised.ok) {
+      return { type: 'invalid', reasonIfInvalid: normalised.reason };
+    }
+
+    normalisedSlugs.push(normalised.slug);
+  }
+
+  const slugs = normalisedSlugs as [string, string, string, string];
+  const canonicalJsonPath = `/results/${slugs
+    .map((slug, index) => (index === slugs.length - 1 ? `${slug}.json` : slug))
+    .join('/')}`;
+
+  return {
+    type: 'json',
+    slugs,
+    canonicalJsonPath,
+  };
+};


### PR DESCRIPTION
## Summary
- add a dedicated LiveRC URL parser that normalises JSON result paths and recognises legacy HTML links
- integrate the parser into the import service to reuse canonical slug parsing and improve error reporting
- cover the parser with unit tests for valid, legacy HTML, and invalid URL scenarios

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68df5577d4ec8321a0c453c1a922055f