### PR TITLE
feat: add LiveRC import preview page

### DIFF
--- a/src/app/(dashboard)/import/ImportForm.module.css
+++ b/src/app/(dashboard)/import/ImportForm.module.css
@@ -1,0 +1,205 @@
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.inputGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.label {
+  font-weight: 600;
+}
+
+.input {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: 0.9rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-fg);
+  font-size: 1rem;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.input:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-color: color-mix(in srgb, var(--color-accent) 60%, var(--color-border) 40%);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-accent) 12%, transparent 88%);
+}
+
+.helper {
+  margin: 0;
+  color: var(--color-fg-muted);
+  font-size: 0.95rem;
+}
+
+.error {
+  margin: 0;
+  font-size: 0.95rem;
+  color: color-mix(in srgb, var(--color-fg) 65%, var(--color-bg) 35%);
+}
+
+.previewCard {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: var(--shadow-elevated);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.previewHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.previewTitle {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.badge {
+  align-self: flex-start;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: color-mix(in srgb, var(--color-accent) 18%, var(--color-bg) 82%);
+  color: var(--color-accent);
+}
+
+.detailsList {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  gap: 1rem;
+}
+
+.detailsItem {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background: var(--color-surface-overlay);
+}
+
+.detailLabel {
+  margin: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-fg-muted);
+}
+
+.detailValue {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.importButton {
+  padding: 0.75rem 1.5rem;
+  border-radius: 0.85rem;
+  border: none;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  background: var(--color-accent);
+  color: var(--color-bg);
+  transition: transform 120ms ease, box-shadow 120ms ease, opacity 120ms ease;
+}
+
+.importButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  box-shadow: none;
+}
+
+.importButton:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-elevated-strong);
+}
+
+.tipsToggle {
+  background: transparent;
+  border: none;
+  color: var(--color-accent);
+  font-size: 0.95rem;
+  cursor: pointer;
+  padding: 0;
+  text-decoration: underline;
+}
+
+.tipsPanel {
+  background: var(--color-surface-overlay);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+.tipsList {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  list-style: decimal;
+}
+
+.responsePanel {
+  border-radius: 0.9rem;
+  padding: 1rem 1.25rem;
+  background: var(--color-surface-overlay);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.responseTitle {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.responseMeta {
+  margin: 0;
+  color: var(--color-fg-muted);
+  font-size: 0.85rem;
+}
+
+.responsePre {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  overflow-x: auto;
+  background: transparent;
+  color: var(--color-fg);
+}
+
+@media (max-width: 36rem) {
+  .previewCard {
+    padding: 1.25rem;
+  }
+
+  .importButton {
+    width: 100%;
+    text-align: center;
+  }
+}

--- a/src/app/(dashboard)/import/ImportForm.tsx
+++ b/src/app/(dashboard)/import/ImportForm.tsx
@@ -1,0 +1,326 @@
+'use client';
+
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+
+import {
+  LiveRcUrlInvalidReasons,
+  type LiveRcJsonUrlParseResult,
+  type LiveRcUrlParseResult,
+  parseLiveRcUrl,
+} from '@core/app/services/liveRcUrlParser';
+import type { LiveRcImportSummary } from '@core/app/services/importLiveRc';
+
+import styles from './ImportForm.module.css';
+
+type ParsedState =
+  | { kind: 'empty' }
+  | { kind: 'invalid'; message: string }
+  | { kind: 'html' }
+  | {
+      kind: 'json';
+      result: LiveRcJsonUrlParseResult;
+      canonicalAbsoluteJsonUrl: string;
+    };
+
+type ImportSuccess = {
+  status: 'success';
+  summary: LiveRcImportSummary;
+  requestId?: string;
+};
+
+type ImportFailure = {
+  status: 'error';
+  statusCode: number;
+  requestId?: string;
+  error: unknown;
+};
+
+type SubmissionState = ImportSuccess | ImportFailure | null;
+
+const slugToTitle = (slug: string) =>
+  slug
+    .split(/[-_]+/)
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+
+const parseInput = (value: string): ParsedState => {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return { kind: 'empty' };
+  }
+
+  let parsedUrl: URL;
+
+  try {
+    parsedUrl = new URL(trimmed);
+  } catch {
+    return { kind: 'invalid', message: LiveRcUrlInvalidReasons.INVALID_ABSOLUTE_URL };
+  }
+
+  let result: LiveRcUrlParseResult;
+  try {
+    result = parseLiveRcUrl(trimmed);
+  } catch {
+    return { kind: 'invalid', message: LiveRcUrlInvalidReasons.INVALID_ABSOLUTE_URL };
+  }
+
+  if (result.type === 'invalid') {
+    return { kind: 'invalid', message: result.reasonIfInvalid };
+  }
+
+  if (result.type === 'html') {
+    return { kind: 'html' };
+  }
+
+  const canonicalAbsoluteJsonUrl = new URL(result.canonicalJsonPath, parsedUrl.origin).toString();
+
+  return { kind: 'json', result, canonicalAbsoluteJsonUrl };
+};
+
+const formatError = (error: unknown) => {
+  if (!error) {
+    return 'Unknown error while importing.';
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  try {
+    return JSON.stringify(error, null, 2);
+  } catch {
+    return 'Unexpected error payload.';
+  }
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const isImportSummary = (value: unknown): value is LiveRcImportSummary => {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  return (
+    typeof value.eventId === 'string' &&
+    typeof value.raceClassId === 'string' &&
+    typeof value.sessionId === 'string' &&
+    typeof value.raceId === 'string' &&
+    typeof value.sourceUrl === 'string'
+  );
+};
+
+export default function ImportForm() {
+  const [url, setUrl] = useState('');
+  const [tipsOpen, setTipsOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submission, setSubmission] = useState<SubmissionState>(null);
+
+  const parsed = useMemo(() => parseInput(url), [url]);
+
+  useEffect(() => {
+    if (parsed.kind !== 'html' && tipsOpen) {
+      setTipsOpen(false);
+    }
+  }, [parsed.kind, tipsOpen]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (parsed.kind !== 'json') {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmission(null);
+
+    try {
+      const response = await fetch('/api/liverc/import', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          url: parsed.canonicalAbsoluteJsonUrl,
+          includeOutlaps: false,
+        }),
+      });
+
+      const payload: unknown = await response.json().catch(() => null);
+      const requestId =
+        isRecord(payload) && typeof payload.requestId === 'string' ? payload.requestId : undefined;
+
+      if (response.ok) {
+        const summary =
+          isRecord(payload) && 'data' in payload && isImportSummary(payload.data)
+            ? payload.data
+            : undefined;
+
+        if (summary) {
+          setSubmission({
+            status: 'success',
+            summary,
+            requestId,
+          });
+          return;
+        }
+
+        setSubmission({
+          status: 'error',
+          statusCode: response.status,
+          requestId,
+          error: 'Import succeeded but response payload was missing summary data.',
+        });
+        return;
+      }
+
+      setSubmission({
+        status: 'error',
+        statusCode: response.status,
+        requestId,
+        error: isRecord(payload) && 'error' in payload ? payload.error : payload,
+      });
+    } catch (error) {
+      setSubmission({
+        status: 'error',
+        statusCode: 0,
+        error,
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const renderPreview = () => {
+    if (parsed.kind === 'empty') {
+      return null;
+    }
+
+    if (parsed.kind === 'invalid') {
+      return <p className={styles.error}>{parsed.message}</p>;
+    }
+
+    if (parsed.kind === 'html') {
+      return (
+        <div className={styles.previewCard}>
+          <div className={styles.previewHeader}>
+            <span className={styles.badge}>Needs resolving</span>
+            <h2 className={styles.previewTitle}>Legacy LiveRC page detected</h2>
+            <p className={styles.helper}>
+              This link points to the older HTML results page. Resolve it to a JSON results URL
+              before importing.
+            </p>
+          </div>
+          <button
+            type="button"
+            className={styles.tipsToggle}
+            onClick={() => setTipsOpen((previous) => !previous)}
+            aria-expanded={tipsOpen}
+          >
+            How to get the JSON link
+          </button>
+          {tipsOpen ? (
+            <div className={styles.tipsPanel}>
+              <p className={styles.helper}>You can use your browser&rsquo;s developer tools:</p>
+              <ol className={styles.tipsList}>
+                <li>Open the LiveRC race page in a new tab.</li>
+                <li>Launch DevTools (Cmd/Ctrl+Shift+I) and switch to the Network tab.</li>
+                <li>
+                  Reload the page and filter for “.json” requests under <code>/results/</code>.
+                </li>
+                <li>
+                  Right-click the matching request and choose “Copy → Copy link address”.
+                  <br />
+                  Paste that JSON link here.
+                </li>
+              </ol>
+            </div>
+          ) : null}
+        </div>
+      );
+    }
+
+    return (
+      <div className={styles.previewCard}>
+        <div className={styles.previewHeader}>
+          <h2 className={styles.previewTitle}>Import ready</h2>
+          <p className={styles.helper}>
+            Review the detected event details before sending the import request.
+          </p>
+        </div>
+        <div className={styles.detailsList}>
+          <div className={styles.detailsItem}>
+            <p className={styles.detailLabel}>Event</p>
+            <p className={styles.detailValue}>{slugToTitle(parsed.result.slugs[0])}</p>
+          </div>
+          <div className={styles.detailsItem}>
+            <p className={styles.detailLabel}>Class</p>
+            <p className={styles.detailValue}>{slugToTitle(parsed.result.slugs[1])}</p>
+          </div>
+          <div className={styles.detailsItem}>
+            <p className={styles.detailLabel}>Round</p>
+            <p className={styles.detailValue}>{slugToTitle(parsed.result.slugs[2])}</p>
+          </div>
+          <div className={styles.detailsItem}>
+            <p className={styles.detailLabel}>Race</p>
+            <p className={styles.detailValue}>{slugToTitle(parsed.result.slugs[3])}</p>
+          </div>
+        </div>
+        <div className={styles.actions}>
+          <button type="submit" className={styles.importButton} disabled={isSubmitting}>
+            {isSubmitting ? 'Importing…' : 'Import'}
+          </button>
+          <p className={styles.helper}>{parsed.canonicalAbsoluteJsonUrl}</p>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <form className={styles.form} onSubmit={handleSubmit}>
+      <div className={styles.inputGroup}>
+        <label className={styles.label} htmlFor="liverc-url">
+          LiveRC link
+        </label>
+        <input
+          id="liverc-url"
+          name="liverc-url"
+          className={styles.input}
+          placeholder="Paste a LiveRC link (page or .json)"
+          value={url}
+          onChange={(event) => {
+            setUrl(event.target.value);
+            setSubmission(null);
+          }}
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <p className={styles.helper}>
+          We only parse the link locally. The import request is sent once you confirm.
+        </p>
+      </div>
+      {renderPreview()}
+      {submission ? (
+        <div className={styles.responsePanel}>
+          <h3 className={styles.responseTitle}>
+            {submission.status === 'success' ? 'Import queued' : 'Import failed'}
+          </h3>
+          {'requestId' in submission && submission.requestId ? (
+            <p className={styles.responseMeta}>Request ID: {submission.requestId}</p>
+          ) : null}
+          {submission.status === 'success' ? (
+            <pre className={styles.responsePre}>{JSON.stringify(submission.summary, null, 2)}</pre>
+          ) : (
+            <pre className={styles.responsePre}>{formatError(submission.error)}</pre>
+          )}
+        </div>
+      ) : null}
+    </form>
+  );
+}

--- a/src/app/(dashboard)/import/page.module.css
+++ b/src/app/(dashboard)/import/page.module.css
@@ -1,0 +1,37 @@
+.container {
+  max-width: 52rem;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.title {
+  margin: 0;
+  font-size: 2rem;
+  line-height: 1.2;
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--color-fg-muted);
+  max-width: 42rem;
+}
+
+@media (max-width: 40rem) {
+  .container {
+    padding: 2.5rem 1.25rem 3rem;
+    gap: 1.5rem;
+  }
+
+  .title {
+    font-size: 1.6rem;
+  }
+}

--- a/src/app/(dashboard)/import/page.tsx
+++ b/src/app/(dashboard)/import/page.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next';
+
+import ImportForm from './ImportForm';
+import styles from './page.module.css';
+
+export const metadata: Metadata = {
+  title: 'Import from LiveRC',
+  description: 'Preview LiveRC results links before triggering an import.',
+};
+
+export default function ImportPage() {
+  return (
+    <div className={styles.container}>
+      <header className={styles.header}>
+        <h1 className={styles.title}>Import from LiveRC</h1>
+        <p className={styles.subtitle}>
+          Paste a LiveRC results link to see whether it resolves to an import-ready JSON endpoint.
+        </p>
+      </header>
+      <ImportForm />
+    </div>
+  );
+}

--- a/src/core/app/index.ts
+++ b/src/core/app/index.ts
@@ -6,3 +6,4 @@ export * from './ports/raceClassRepository';
 export * from './ports/sessionRepository';
 export * from './services/getLapSummary';
 export * from './services/importLiveRc';
+export * from './services/liveRcUrlParser';

--- a/src/core/app/services/liveRcUrlParser.ts
+++ b/src/core/app/services/liveRcUrlParser.ts
@@ -1,0 +1,9 @@
+export {
+  LiveRcUrlInvalidReasons,
+  type LiveRcUrlInvalidReason,
+  type LiveRcJsonUrlParseResult,
+  type LiveRcHtmlUrlParseResult,
+  type LiveRcInvalidUrlParseResult,
+  type LiveRcUrlParseResult,
+  parseLiveRcUrl,
+} from '../../liverc/urlParser';


### PR DESCRIPTION
## Summary
- add a LiveRC import page under the dashboard that parses links locally and previews the detected event before import
- expose the LiveRC URL parser types through the core app exports so client components can consume them without breaking layering
- style the import form, preview states, and tips panel with lightweight CSS modules

## Testing
- npm run typecheck
- npm run lint *(fails: existing lint violations in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68df58f4b8508321bae44b9bbc4664c0