### PR TITLE
Add LiveRC resolver guidance UI

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,8 @@ const nextConfig = {
   },
   env: {
     TZ: process.env.TZ ?? 'Australia/Sydney',
+    ENABLE_LIVERC_RESOLVER: process.env.ENABLE_LIVERC_RESOLVER,
+    LIVERC_HTTP_BASE: process.env.LIVERC_HTTP_BASE,
   },
   poweredByHeader: false,
   async redirects() {

--- a/src/app/(dashboard)/import/ImportForm.module.css
+++ b/src/app/(dashboard)/import/ImportForm.module.css
@@ -22,7 +22,9 @@
   background: var(--color-surface);
   color: var(--color-fg);
   font-size: 1rem;
-  transition: border-color 120ms ease, box-shadow 120ms ease;
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease;
 }
 
 .input:focus {
@@ -53,6 +55,11 @@
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+}
+
+.previewActions {
+  display: flex;
+  gap: 0.75rem;
 }
 
 .previewHeader {
@@ -112,6 +119,25 @@
   align-items: center;
 }
 
+.resolveButton {
+  padding: 0.6rem 1.1rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-overlay);
+  color: var(--color-fg);
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease;
+}
+
+.resolveButton:hover {
+  background: color-mix(in srgb, var(--color-surface-overlay) 70%, var(--color-bg) 30%);
+  border-color: color-mix(in srgb, var(--color-border) 70%, var(--color-accent) 30%);
+}
+
 .importButton {
   padding: 0.75rem 1.5rem;
   border-radius: 0.85rem;
@@ -121,7 +147,10 @@
   cursor: pointer;
   background: var(--color-accent);
   color: var(--color-bg);
-  transition: transform 120ms ease, box-shadow 120ms ease, opacity 120ms ease;
+  transition:
+    transform 120ms ease,
+    box-shadow 120ms ease,
+    opacity 120ms ease;
 }
 
 .importButton:disabled {
@@ -191,6 +220,58 @@
   overflow-x: auto;
   background: transparent;
   color: var(--color-fg);
+}
+
+.modalBackdrop {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in srgb, var(--color-bg) 35%, transparent 65%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 20;
+}
+
+.modal {
+  max-width: 28rem;
+  width: 100%;
+  background: var(--color-surface);
+  border-radius: 1rem;
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-elevated-strong);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modalTitle {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.modalBody {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.modalBody p {
+  margin: 0;
+}
+
+.modalActions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.modalLink {
+  display: inline-block;
+  margin-top: 0.35rem;
+  color: var(--color-accent);
+  text-decoration: underline;
 }
 
 @media (max-width: 36rem) {


### PR DESCRIPTION
## Summary
- add a flag-guarded Resolve control that normalises missing .json slugs and opens guidance for HTML LiveRC links
- surface proxy- and fixture-related instructions in a modal when LIVERC_HTTP_BASE is configured
- style the import form with resolver button and modal affordances

## Testing
- pnpm lint *(fails: repository has existing prettier/@typescript-eslint findings outside this change)*

------
https://chatgpt.com/codex/tasks/task_e_68df5bf88da883218a8d4fe030cf49db