### PR TITLE
feat: add optional LiveRC import wizard

### DIFF
--- a/src/app/(dashboard)/import/ImportForm.module.css
+++ b/src/app/(dashboard)/import/ImportForm.module.css
@@ -4,6 +4,48 @@
   gap: 1.75rem;
 }
 
+.wizardSection {
+  border: 1px solid var(--color-border);
+  border-radius: 1rem;
+  background: var(--color-surface);
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.wizardHeader {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.wizardTitle {
+  margin: 0;
+  font-weight: 600;
+}
+
+.wizardToggle {
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-overlay);
+  color: var(--color-fg);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease;
+}
+
+.wizardToggle:hover {
+  background: color-mix(in srgb, var(--color-surface-overlay) 65%, var(--color-bg) 35%);
+  border-color: color-mix(in srgb, var(--color-border) 70%, var(--color-accent) 30%);
+}
+
 .inputGroup {
   display: flex;
   flex-direction: column;

--- a/src/app/(dashboard)/import/ImportForm.tsx
+++ b/src/app/(dashboard)/import/ImportForm.tsx
@@ -11,6 +11,11 @@ import {
 import type { LiveRcImportSummary } from '@core/app/services/importLiveRc';
 
 import styles from './ImportForm.module.css';
+import Wizard from './Wizard';
+
+type ImportFormProps = {
+  enableWizard?: boolean;
+};
 
 type ParsedState =
   | { kind: 'empty' }
@@ -128,12 +133,13 @@ const isImportSummary = (value: unknown): value is LiveRcImportSummary => {
   );
 };
 
-export default function ImportForm() {
+export default function ImportForm({ enableWizard = false }: ImportFormProps) {
   const [url, setUrl] = useState('');
   const [tipsOpen, setTipsOpen] = useState(false);
   const [resolveModalOpen, setResolveModalOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submission, setSubmission] = useState<SubmissionState>(null);
+  const [wizardOpen, setWizardOpen] = useState(false);
 
   const parsed = useMemo(() => parseInput(url), [url]);
   const resolveModalTitleId = useId();
@@ -340,6 +346,30 @@ export default function ImportForm() {
 
   return (
     <form className={styles.form} onSubmit={handleSubmit}>
+      {enableWizard ? (
+        <section className={styles.wizardSection}>
+          <div className={styles.wizardHeader}>
+            <p className={styles.wizardTitle}>Need help finding the JSON link?</p>
+            <button
+              type="button"
+              className={styles.wizardToggle}
+              onClick={() => setWizardOpen((previous) => !previous)}
+              aria-expanded={wizardOpen}
+            >
+              {wizardOpen ? 'Hide wizard' : 'Open wizard'}
+            </button>
+          </div>
+          {wizardOpen ? (
+            <Wizard
+              onComplete={(wizardUrl) => {
+                setUrl(wizardUrl);
+                setSubmission(null);
+                setWizardOpen(false);
+              }}
+            />
+          ) : null}
+        </section>
+      ) : null}
       <div className={styles.inputGroup}>
         <label className={styles.label} htmlFor="liverc-url">
           LiveRC link

--- a/src/app/(dashboard)/import/Wizard.module.css
+++ b/src/app/(dashboard)/import/Wizard.module.css
@@ -1,0 +1,162 @@
+.wizard {
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.stepIndicator {
+  font-size: 0.85rem;
+  color: var(--color-fg-muted);
+  margin: 0;
+}
+
+.stepTitle {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.stepDescription {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--color-fg-muted);
+}
+
+.input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 0.8rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-overlay);
+  color: var(--color-fg);
+  font-size: 0.95rem;
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.input:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-color: color-mix(in srgb, var(--color-accent) 60%, var(--color-border) 40%);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-accent) 12%, transparent 88%);
+}
+
+.helperRow {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.suggestions,
+.examples {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.chipButton {
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-fg);
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease;
+}
+
+.chipButton:hover {
+  background: color-mix(in srgb, var(--color-surface) 70%, var(--color-bg) 30%);
+  border-color: color-mix(in srgb, var(--color-border) 70%, var(--color-accent) 30%);
+}
+
+.controls {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.backButton {
+  padding: 0.6rem 1.1rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: var(--color-fg);
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.nextButton {
+  padding: 0.7rem 1.4rem;
+  border-radius: 0.85rem;
+  border: none;
+  background: var(--color-accent);
+  color: var(--color-bg);
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition:
+    transform 120ms ease,
+    opacity 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.nextButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  box-shadow: none;
+}
+
+.nextButton:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-elevated-strong);
+}
+
+.previewUrl {
+  margin: 0;
+  font-family: var(
+    --font-mono,
+    ui-monospace,
+    SFMono-Regular,
+    SFMono,
+    Menlo,
+    Monaco,
+    Consolas,
+    'Liberation Mono',
+    'Courier New',
+    monospace
+  );
+  font-size: 0.9rem;
+  word-break: break-all;
+}
+
+.summaryCard {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: var(--color-surface-overlay);
+  border-radius: 0.9rem;
+  padding: 1rem;
+}
+
+.summaryList {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+}
+
+.tooltip {
+  font-size: 0.85rem;
+  color: var(--color-fg-muted);
+}

--- a/src/app/(dashboard)/import/Wizard.tsx
+++ b/src/app/(dashboard)/import/Wizard.tsx
@@ -1,0 +1,298 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import styles from './Wizard.module.css';
+
+type WizardProps = {
+  onComplete: (url: string) => void;
+};
+
+type WizardStep = 0 | 1 | 2 | 3 | 4 | 5;
+
+type WizardHistory = {
+  hosts: string[];
+  classes: string[];
+};
+
+const STORAGE_KEY = 'mre-import-wizard-history-v1';
+
+const emptyHistory: WizardHistory = {
+  hosts: [],
+  classes: [],
+};
+
+const normaliseHost = (value: string) =>
+  value
+    .trim()
+    .replace(/^https?:\/\//i, '')
+    .replace(/\/?$/, '')
+    .replace(/\/$/, '');
+
+const normaliseSlug = (value: string) => value.trim();
+
+export default function Wizard({ onComplete }: WizardProps) {
+  const [step, setStep] = useState<WizardStep>(0);
+  const [host, setHost] = useState('');
+  const [eventSlug, setEventSlug] = useState('');
+  const [classSlug, setClassSlug] = useState('');
+  const [roundSlug, setRoundSlug] = useState('');
+  const [raceSlug, setRaceSlug] = useState('');
+  const [history, setHistory] = useState<WizardHistory>(emptyHistory);
+  const [completedUrl, setCompletedUrl] = useState<string | null>(null);
+
+  const hasHydrated = useRef(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw) as Partial<WizardHistory>;
+        setHistory({
+          hosts: Array.isArray(parsed.hosts)
+            ? [...new Set(parsed.hosts.filter((item) => typeof item === 'string'))]
+            : [],
+          classes: Array.isArray(parsed.classes)
+            ? [...new Set(parsed.classes.filter((item) => typeof item === 'string'))]
+            : [],
+        });
+      }
+    } catch {
+      setHistory(emptyHistory);
+    }
+
+    hasHydrated.current = true;
+  }, []);
+
+  useEffect(() => {
+    if (!hasHydrated.current || typeof window === 'undefined') {
+      return;
+    }
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(history));
+  }, [history]);
+
+  const steps = useMemo(
+    () => [
+      {
+        id: 'host',
+        title: 'Club host',
+        description: 'Enter the LiveRC club hostname (without https://).',
+        value: host,
+        setValue: setHost,
+        placeholder: 'example.liverc.com',
+      },
+      {
+        id: 'event',
+        title: 'Event slug',
+        description: 'Use lowercase letters and hyphens only.',
+        value: eventSlug,
+        setValue: setEventSlug,
+        placeholder: 'summer-series-round-1',
+      },
+      {
+        id: 'class',
+        title: 'Class slug',
+        description: 'Match the class slug used by LiveRC.',
+        value: classSlug,
+        setValue: setClassSlug,
+        placeholder: 'mod-2wd-buggy',
+      },
+      {
+        id: 'round',
+        title: 'Round slug',
+        description: 'Often the qualifier or main identifier.',
+        value: roundSlug,
+        setValue: setRoundSlug,
+        placeholder: 'qualifier-1',
+      },
+      {
+        id: 'race',
+        title: 'Race slug',
+        description: 'Usually “race-1”, “main-a1”, etc.',
+        value: raceSlug,
+        setValue: setRaceSlug,
+        placeholder: 'race-1',
+      },
+    ],
+    [host, eventSlug, classSlug, roundSlug, raceSlug],
+  );
+
+  const isSummaryStep = step === 5;
+
+  const canonicalUrl = useMemo(() => {
+    const trimmedHost = normaliseHost(host);
+    const trimmedEvent = normaliseSlug(eventSlug);
+    const trimmedClass = normaliseSlug(classSlug);
+    const trimmedRound = normaliseSlug(roundSlug);
+    const trimmedRace = normaliseSlug(raceSlug);
+
+    if (!trimmedHost || !trimmedEvent || !trimmedClass || !trimmedRound || !trimmedRace) {
+      return null;
+    }
+
+    return `https://${trimmedHost}/results/${trimmedEvent}/${trimmedClass}/${trimmedRound}/${trimmedRace}.json`;
+  }, [host, eventSlug, classSlug, roundSlug, raceSlug]);
+
+  const goNext = useCallback(() => {
+    setStep((current) => (current < 5 ? ((current + 1) as WizardStep) : current));
+  }, []);
+
+  const goBack = useCallback(() => {
+    setStep((current) => (current > 0 ? ((current - 1) as WizardStep) : current));
+  }, []);
+
+  const handleSubmitStep = useCallback(() => {
+    if (isSummaryStep) {
+      if (!canonicalUrl) {
+        return;
+      }
+
+      onComplete(canonicalUrl);
+      setCompletedUrl(canonicalUrl);
+      setHistory((previous) => {
+        const nextHosts = [
+          normaliseHost(host),
+          ...previous.hosts.filter((item) => item !== normaliseHost(host)),
+        ].filter(Boolean);
+        const nextClasses = [
+          normaliseSlug(classSlug),
+          ...previous.classes.filter((item) => item !== normaliseSlug(classSlug)),
+        ].filter(Boolean);
+
+        return {
+          hosts: nextHosts.slice(0, 5),
+          classes: nextClasses.slice(0, 5),
+        };
+      });
+      return;
+    }
+
+    const currentStep = steps[step];
+    const trimmedValue =
+      currentStep.id === 'host'
+        ? normaliseHost(currentStep.value)
+        : normaliseSlug(currentStep.value);
+
+    currentStep.setValue(trimmedValue);
+    goNext();
+  }, [canonicalUrl, classSlug, goNext, host, isSummaryStep, onComplete, step, steps]);
+
+  useEffect(() => {
+    if (step === 5 && !canonicalUrl) {
+      setStep(4);
+    }
+  }, [canonicalUrl, step]);
+
+  const currentStep = steps[step] ?? steps[steps.length - 1];
+
+  const canAdvance = useMemo(() => {
+    if (isSummaryStep) {
+      return Boolean(canonicalUrl);
+    }
+
+    const value = currentStep.value.trim();
+    return value.length > 0;
+  }, [canonicalUrl, currentStep.value, isSummaryStep]);
+
+  const showSuggestions = currentStep.id === 'host' && history.hosts.length > 0;
+  const showExamples = currentStep.id === 'class' && history.classes.length > 0;
+
+  return (
+    <div className={styles.wizard}>
+      <p className={styles.stepIndicator}>
+        Step {Math.min(step + 1, steps.length + 1)} of {steps.length + 1}
+      </p>
+      {isSummaryStep ? (
+        <div className={styles.summaryCard}>
+          <h3 className={styles.stepTitle}>Summary</h3>
+          <p className={styles.stepDescription}>
+            Confirm the generated JSON link and send it to the import form.
+          </p>
+          {canonicalUrl ? <p className={styles.previewUrl}>{canonicalUrl}</p> : null}
+          <ol className={styles.summaryList}>
+            <li>Host: {normaliseHost(host)}</li>
+            <li>Event: {normaliseSlug(eventSlug)}</li>
+            <li>Class: {normaliseSlug(classSlug)}</li>
+            <li>Round: {normaliseSlug(roundSlug)}</li>
+            <li>Race: {normaliseSlug(raceSlug)}</li>
+          </ol>
+          {completedUrl ? (
+            <p className={styles.tooltip}>Link sent to the form. You can close the wizard.</p>
+          ) : null}
+        </div>
+      ) : (
+        <div className={styles.helperRow}>
+          <h3 className={styles.stepTitle}>{currentStep.title}</h3>
+          <p className={styles.stepDescription}>{currentStep.description}</p>
+          {currentStep.id === 'event' ? (
+            <p className={styles.tooltip}>Tip: lowercase, hyphens</p>
+          ) : null}
+          <input
+            key={currentStep.id}
+            className={styles.input}
+            value={currentStep.value}
+            onChange={(event) => {
+              currentStep.setValue(event.target.value);
+              setCompletedUrl(null);
+            }}
+            placeholder={currentStep.placeholder}
+            autoComplete="off"
+            spellCheck={false}
+          />
+          {showSuggestions ? (
+            <ul className={styles.suggestions}>
+              {history.hosts.map((item) => (
+                <li key={item}>
+                  <button
+                    type="button"
+                    className={styles.chipButton}
+                    onClick={() => currentStep.setValue(item)}
+                  >
+                    {item}
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          {showExamples ? (
+            <div className={styles.helperRow}>
+              <p className={styles.tooltip}>Recent class slugs</p>
+              <ul className={styles.examples}>
+                {history.classes.map((item) => (
+                  <li key={item}>
+                    <button
+                      type="button"
+                      className={styles.chipButton}
+                      onClick={() => currentStep.setValue(item)}
+                    >
+                      {item}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : null}
+        </div>
+      )}
+      <div className={styles.controls}>
+        <button type="button" className={styles.backButton} onClick={goBack} disabled={step === 0}>
+          Back
+        </button>
+        <button
+          type="button"
+          className={styles.nextButton}
+          onClick={handleSubmitStep}
+          disabled={!canAdvance}
+        >
+          {isSummaryStep ? 'Send to form' : 'Next'}
+        </button>
+      </div>
+      {!isSummaryStep && canonicalUrl ? <p className={styles.previewUrl}>{canonicalUrl}</p> : null}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/import/page.tsx
+++ b/src/app/(dashboard)/import/page.tsx
@@ -8,6 +8,8 @@ export const metadata: Metadata = {
   description: 'Preview LiveRC results links before triggering an import.',
 };
 
+const enableWizard = process.env.ENABLE_IMPORT_WIZARD === '1';
+
 export default function ImportPage() {
   return (
     <div className={styles.container}>
@@ -17,7 +19,7 @@ export default function ImportPage() {
           Paste a LiveRC results link to see whether it resolves to an import-ready JSON endpoint.
         </p>
       </header>
-      <ImportForm />
+      <ImportForm enableWizard={enableWizard} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add an optional import wizard that walks through host/event/class/round/race slugs and feeds the composed JSON URL back into the LiveRC import form when ENABLE_IMPORT_WIZARD is enabled
- persist recent host and class selections locally so the wizard can offer quick suggestions and examples on subsequent runs
- surface wizard controls and styling within the existing import form layout while keeping the page unchanged when the flag is disabled

## Testing
- npm run lint *(fails: existing prettier/@typescript-eslint findings in untouched core files)*

------
https://chatgpt.com/codex/tasks/task_e_68df5f9c07b083218bf51b4541a77827