### PR TITLE
Add bulk LiveRC import tab

### DIFF
--- a/src/app/(dashboard)/import/ImportForm.module.css
+++ b/src/app/(dashboard)/import/ImportForm.module.css
@@ -1,7 +1,64 @@
+.formWrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.tabList {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  align-self: flex-start;
+}
+
+.tabButton {
+  border: none;
+  background: transparent;
+  color: var(--color-fg-muted);
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0.4rem 1.1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition:
+    color 120ms ease,
+    background-color 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.tabButton:hover {
+  color: var(--color-fg);
+}
+
+.tabButton:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.tabButtonActive {
+  background: var(--color-accent);
+  color: var(--color-bg);
+  box-shadow: var(--shadow-elevated);
+}
+
+.tabButtonActive:hover {
+  color: var(--color-bg);
+}
+
 .form {
   display: flex;
   flex-direction: column;
   gap: 1.75rem;
+}
+
+.bulkSection {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
 .wizardSection {
@@ -70,6 +127,29 @@
 }
 
 .input:focus {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-color: color-mix(in srgb, var(--color-accent) 60%, var(--color-border) 40%);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-accent) 12%, transparent 88%);
+}
+
+.bulkTextarea {
+  width: 100%;
+  min-height: 10rem;
+  padding: 0.85rem 1rem;
+  border-radius: 0.9rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-fg);
+  font-size: 1rem;
+  font-family: inherit;
+  resize: vertical;
+  transition:
+    border-color 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.bulkTextarea:focus {
   outline: 2px solid var(--color-accent);
   outline-offset: 2px;
   border-color: color-mix(in srgb, var(--color-accent) 60%, var(--color-border) 40%);
@@ -206,6 +286,110 @@
   box-shadow: var(--shadow-elevated-strong);
 }
 
+.bulkTableWrapper {
+  border: 1px solid var(--color-border);
+  border-radius: 1rem;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-elevated);
+  overflow: hidden;
+  overflow-x: auto;
+}
+
+.bulkTable {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 42rem;
+}
+
+.bulkTable thead {
+  background: var(--color-surface-overlay);
+}
+
+.bulkTable th,
+.bulkTable td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--color-border);
+  text-align: left;
+  font-size: 0.95rem;
+}
+
+.bulkTable th {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-fg-muted);
+}
+
+.bulkTable tbody tr:last-of-type td {
+  border-bottom: none;
+}
+
+.statusCell {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: flex-start;
+}
+
+.statusBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 0.85rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.statusToneDefault {
+  background: color-mix(in srgb, var(--color-surface-overlay) 70%, var(--color-bg) 30%);
+  color: var(--color-fg);
+}
+
+.statusToneInfo {
+  background: color-mix(in srgb, var(--color-accent) 22%, var(--color-bg) 78%);
+  color: var(--color-accent);
+}
+
+.statusToneSuccess {
+  background: color-mix(in srgb, var(--color-success) 22%, var(--color-bg) 78%);
+  color: var(--color-success);
+}
+
+.statusToneDanger {
+  background: color-mix(in srgb, var(--color-danger) 26%, var(--color-bg) 74%);
+  color: var(--color-danger);
+}
+
+.statusToneWarning {
+  background: color-mix(in srgb, var(--color-warning) 28%, var(--color-bg) 72%);
+  color: var(--color-warning);
+}
+
+.statusNote {
+  font-size: 0.85rem;
+  color: var(--color-fg-muted);
+}
+
+.bulkEmptyState {
+  margin: 0;
+  padding: 1.25rem 1.5rem;
+  border: 1px dashed var(--color-border);
+  border-radius: 1rem;
+  background: var(--color-surface);
+  color: var(--color-fg-muted);
+  font-size: 0.95rem;
+}
+
+.bulkActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
 .tipsToggle {
   background: transparent;
   border: none;
@@ -317,12 +501,21 @@
 }
 
 @media (max-width: 36rem) {
-  .previewCard {
-    padding: 1.25rem;
+  .tabList {
+    width: 100%;
+    justify-content: space-between;
   }
 
   .importButton {
     width: 100%;
     text-align: center;
+  }
+
+  .bulkTable {
+    min-width: 32rem;
+  }
+
+  .previewCard {
+    padding: 1.25rem;
   }
 }

--- a/src/app/(dashboard)/import/ImportForm.tsx
+++ b/src/app/(dashboard)/import/ImportForm.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { useEffect, useId, useMemo, useState, type FormEvent } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+} from 'react';
 
 import {
   LiveRcUrlInvalidReasons,
@@ -43,6 +51,22 @@ type ImportFailure = {
 };
 
 type SubmissionState = ImportSuccess | ImportFailure | null;
+
+type BulkImportRowStatus = 'idle' | 'queued' | 'importing' | 'done' | 'error';
+
+type BulkImportRowType = 'json' | 'html' | 'invalid';
+
+type BulkImportRow = {
+  id: string;
+  input: string;
+  host: string;
+  type: BulkImportRowType;
+  slugs?: [string, string, string, string];
+  canonicalAbsoluteJsonUrl?: string;
+  status: BulkImportRowStatus;
+  statusMessage?: string;
+  requestId?: string;
+};
 
 const slugToTitle = (slug: string) =>
   slug
@@ -134,7 +158,351 @@ const isImportSummary = (value: unknown): value is LiveRcImportSummary => {
   );
 };
 
+const parseBulkInput = (value: string): BulkImportRow[] => {
+  const lines = value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  return lines.map((line, index) => {
+    const id = `${index}-${line}`;
+    let parsedUrl: URL | null = null;
+
+    try {
+      parsedUrl = new URL(line);
+    } catch {
+      parsedUrl = null;
+    }
+
+    let result: LiveRcUrlParseResult;
+    try {
+      result = parseLiveRcUrl(line);
+    } catch {
+      return {
+        id,
+        input: line,
+        host: parsedUrl ? parsedUrl.host : '',
+        type: 'invalid',
+        status: 'idle',
+        statusMessage: LiveRcUrlInvalidReasons.INVALID_ABSOLUTE_URL,
+      };
+    }
+
+    if (result.type === 'json') {
+      const canonicalAbsoluteJsonUrl = parsedUrl
+        ? new URL(result.canonicalJsonPath, parsedUrl.origin).toString()
+        : line;
+
+      return {
+        id,
+        input: line,
+        host: parsedUrl ? parsedUrl.host : '',
+        type: 'json',
+        slugs: result.slugs,
+        canonicalAbsoluteJsonUrl,
+        status: 'idle',
+      } satisfies BulkImportRow;
+    }
+
+    if (result.type === 'html') {
+      return {
+        id,
+        input: line,
+        host: parsedUrl ? parsedUrl.host : '',
+        type: 'html',
+        status: 'idle',
+        statusMessage: 'Needs JSON',
+      } satisfies BulkImportRow;
+    }
+
+    return {
+      id,
+      input: line,
+      host: parsedUrl ? parsedUrl.host : '',
+      type: 'invalid',
+      status: 'idle',
+      statusMessage: result.reasonIfInvalid,
+    } satisfies BulkImportRow;
+  });
+};
+
+type StatusTone = 'default' | 'info' | 'success' | 'danger' | 'warning';
+
+const summariseStatusMessage = (message?: string) => {
+  if (!message) {
+    return undefined;
+  }
+
+  const trimmed = message.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+
+  const [firstLine] = trimmed.split('\n');
+  if (!firstLine) {
+    return undefined;
+  }
+
+  if (firstLine.length > 140) {
+    return `${firstLine.slice(0, 137)}…`;
+  }
+
+  return firstLine;
+};
+
+const getStatusDescriptor = (
+  row: BulkImportRow,
+): { label: string; tone: StatusTone; note?: string } => {
+  if (row.type === 'html') {
+    return {
+      label: 'Needs JSON',
+      tone: 'warning',
+      note: summariseStatusMessage(row.statusMessage),
+    };
+  }
+
+  if (row.type === 'invalid') {
+    return { label: 'Invalid', tone: 'danger', note: summariseStatusMessage(row.statusMessage) };
+  }
+
+  if (row.status === 'queued') {
+    return { label: 'Queued', tone: 'info' };
+  }
+
+  if (row.status === 'importing') {
+    return { label: 'Importing', tone: 'info' };
+  }
+
+  if (row.status === 'done') {
+    return { label: 'Done', tone: 'success', note: summariseStatusMessage(row.statusMessage) };
+  }
+
+  if (row.status === 'error') {
+    return { label: 'Error', tone: 'danger', note: summariseStatusMessage(row.statusMessage) };
+  }
+
+  return { label: 'Ready', tone: 'default' };
+};
+
+const BulkImportTab = ({
+  tabPanelId,
+  labelledById,
+}: {
+  tabPanelId: string;
+  labelledById: string;
+}) => {
+  const [bulkInput, setBulkInput] = useState('');
+  const [rows, setRows] = useState<BulkImportRow[]>([]);
+  const [isImporting, setIsImporting] = useState(false);
+
+  const readyRows = useMemo(
+    () =>
+      rows.filter(
+        (row): row is BulkImportRow & { type: 'json'; canonicalAbsoluteJsonUrl: string } =>
+          row.type === 'json' && typeof row.canonicalAbsoluteJsonUrl === 'string',
+      ),
+    [rows],
+  );
+
+  const handleBulkInputChange = useCallback((event: ChangeEvent<HTMLTextAreaElement>) => {
+    const nextValue = event.target.value;
+    setBulkInput(nextValue);
+    setRows(parseBulkInput(nextValue));
+  }, []);
+
+  const handleImportAll = useCallback(async () => {
+    if (isImporting || readyRows.length === 0) {
+      return;
+    }
+
+    setIsImporting(true);
+    setRows((previous) =>
+      previous.map((row) =>
+        row.type === 'json'
+          ? { ...row, status: 'queued', statusMessage: undefined, requestId: undefined }
+          : row,
+      ),
+    );
+
+    try {
+      for (const row of readyRows) {
+        setRows((previous) =>
+          previous.map((current) =>
+            current.id === row.id
+              ? { ...current, status: 'importing', statusMessage: undefined, requestId: undefined }
+              : current,
+          ),
+        );
+
+        try {
+          const response = await fetch('/api/liverc/import', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              url: row.canonicalAbsoluteJsonUrl,
+              includeOutlaps: false,
+            }),
+          });
+
+          const payload: unknown = await response.json().catch(() => null);
+          const requestId =
+            isRecord(payload) && typeof payload.requestId === 'string'
+              ? payload.requestId
+              : undefined;
+
+          if (response.ok) {
+            setRows((previous) =>
+              previous.map((current) =>
+                current.id === row.id
+                  ? {
+                      ...current,
+                      status: 'done',
+                      statusMessage: requestId ? `Request ${requestId}` : undefined,
+                      requestId,
+                    }
+                  : current,
+              ),
+            );
+            continue;
+          }
+
+          let errorPayload: unknown = payload;
+          if (isRecord(payload) && 'error' in payload) {
+            errorPayload = payload.error;
+          }
+
+          setRows((previous) =>
+            previous.map((current) =>
+              current.id === row.id
+                ? {
+                    ...current,
+                    status: 'error',
+                    statusMessage: formatError(errorPayload),
+                    requestId,
+                  }
+                : current,
+            ),
+          );
+        } catch (error) {
+          setRows((previous) =>
+            previous.map((current) =>
+              current.id === row.id
+                ? {
+                    ...current,
+                    status: 'error',
+                    statusMessage: formatError(error),
+                  }
+                : current,
+            ),
+          );
+        }
+      }
+    } finally {
+      setIsImporting(false);
+    }
+  }, [isImporting, readyRows]);
+
+  const toneClassMap: Record<StatusTone, string> = {
+    default: styles.statusToneDefault,
+    info: styles.statusToneInfo,
+    success: styles.statusToneSuccess,
+    danger: styles.statusToneDanger,
+    warning: styles.statusToneWarning,
+  };
+
+  return (
+    <section
+      id={tabPanelId}
+      className={styles.bulkSection}
+      role="tabpanel"
+      aria-labelledby={labelledById}
+    >
+      <div className={styles.inputGroup}>
+        <label className={styles.label} htmlFor="bulk-liverc-urls">
+          Paste multiple LiveRC links (one per line)
+        </label>
+        <textarea
+          id="bulk-liverc-urls"
+          className={styles.bulkTextarea}
+          placeholder="https://www.liverc.com/..."
+          value={bulkInput}
+          onChange={handleBulkInputChange}
+          spellCheck={false}
+        />
+        <p className={styles.helper}>
+          JSON-ready rows import sequentially. HTML and invalid links are skipped.
+        </p>
+      </div>
+      {rows.length > 0 ? (
+        <div className={styles.bulkTableWrapper}>
+          <table className={styles.bulkTable}>
+            <thead>
+              <tr>
+                <th scope="col">Host</th>
+                <th scope="col">Event</th>
+                <th scope="col">Class</th>
+                <th scope="col">Round</th>
+                <th scope="col">Race</th>
+                <th scope="col">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => {
+                const descriptor = getStatusDescriptor(row);
+                const statusClassName = `${styles.statusBadge} ${toneClassMap[descriptor.tone]}`;
+                const [eventSlug, classSlug, roundSlug, raceSlug] = row.slugs ?? [];
+
+                return (
+                  <tr key={row.id}>
+                    <td>{row.host || '—'}</td>
+                    <td>{eventSlug ? slugToTitle(eventSlug) : '—'}</td>
+                    <td>{classSlug ? slugToTitle(classSlug) : '—'}</td>
+                    <td>{roundSlug ? slugToTitle(roundSlug) : '—'}</td>
+                    <td>{raceSlug ? slugToTitle(raceSlug) : '—'}</td>
+                    <td>
+                      <div className={styles.statusCell}>
+                        <span className={statusClassName}>{descriptor.label}</span>
+                        {descriptor.note ? (
+                          <span className={styles.statusNote} title={row.statusMessage}>
+                            {descriptor.note}
+                          </span>
+                        ) : null}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      ) : (
+        <p className={styles.bulkEmptyState}>
+          Paste LiveRC links above to preview their import status.
+        </p>
+      )}
+      <div className={styles.bulkActions}>
+        <button
+          type="button"
+          className={styles.importButton}
+          onClick={handleImportAll}
+          disabled={isImporting || readyRows.length === 0}
+        >
+          {isImporting ? 'Importing…' : 'Import all'}
+        </button>
+        <p className={styles.helper}>
+          {readyRows.length === 0
+            ? 'Add LiveRC JSON links above to enable bulk import.'
+            : `Queued imports run one at a time (${readyRows.length} ready).`}
+        </p>
+      </div>
+    </section>
+  );
+};
+
 export default function ImportForm({ enableWizard = false, initialUrl }: ImportFormProps) {
+  const [activeTab, setActiveTab] = useState<'single' | 'bulk'>('single');
   const [url, setUrl] = useState(() => initialUrl ?? '');
   const [tipsOpen, setTipsOpen] = useState(false);
   const [resolveModalOpen, setResolveModalOpen] = useState(false);
@@ -143,7 +511,20 @@ export default function ImportForm({ enableWizard = false, initialUrl }: ImportF
   const [wizardOpen, setWizardOpen] = useState(false);
 
   const parsed = useMemo(() => parseInput(url), [url]);
+  const tabSetId = useId();
   const resolveModalTitleId = useId();
+  const singleTabId = `${tabSetId}-single-tab`;
+  const bulkTabId = `${tabSetId}-bulk-tab`;
+  const singlePanelId = `${tabSetId}-single-panel`;
+  const bulkPanelId = `${tabSetId}-bulk-panel`;
+
+  const handleSelectSingle = useCallback(() => {
+    setActiveTab('single');
+  }, []);
+
+  const handleSelectBulk = useCallback(() => {
+    setActiveTab('bulk');
+  }, []);
 
   useEffect(() => {
     if (typeof initialUrl === 'string' && initialUrl.length > 0) {
@@ -163,6 +544,20 @@ export default function ImportForm({ enableWizard = false, initialUrl }: ImportF
       setResolveModalOpen(false);
     }
   }, [parsed.kind, resolveModalOpen]);
+
+  useEffect(() => {
+    if (activeTab === 'bulk') {
+      if (tipsOpen) {
+        setTipsOpen(false);
+      }
+      if (wizardOpen) {
+        setWizardOpen(false);
+      }
+      if (resolveModalOpen) {
+        setResolveModalOpen(false);
+      }
+    }
+  }, [activeTab, resolveModalOpen, tipsOpen, wizardOpen]);
 
   const handleResolve = () => {
     if (!resolverEnabled) {
@@ -352,69 +747,114 @@ export default function ImportForm({ enableWizard = false, initialUrl }: ImportF
     );
   };
 
+  const singleTabClassName = `${styles.tabButton} ${
+    activeTab === 'single' ? styles.tabButtonActive : ''
+  }`.trim();
+  const bulkTabClassName = `${styles.tabButton} ${
+    activeTab === 'bulk' ? styles.tabButtonActive : ''
+  }`.trim();
+
   return (
-    <form className={styles.form} onSubmit={handleSubmit}>
-      {enableWizard ? (
-        <section className={styles.wizardSection}>
-          <div className={styles.wizardHeader}>
-            <p className={styles.wizardTitle}>Need help finding the JSON link?</p>
-            <button
-              type="button"
-              className={styles.wizardToggle}
-              onClick={() => setWizardOpen((previous) => !previous)}
-              aria-expanded={wizardOpen}
-            >
-              {wizardOpen ? 'Hide wizard' : 'Open wizard'}
-            </button>
-          </div>
-          {wizardOpen ? (
-            <Wizard
-              onComplete={(wizardUrl) => {
-                setUrl(wizardUrl);
-                setSubmission(null);
-                setWizardOpen(false);
-              }}
-            />
-          ) : null}
-        </section>
-      ) : null}
-      <div className={styles.inputGroup}>
-        <label className={styles.label} htmlFor="liverc-url">
-          LiveRC link
-        </label>
-        <input
-          id="liverc-url"
-          name="liverc-url"
-          className={styles.input}
-          placeholder="Paste a LiveRC link (page or .json)"
-          value={url}
-          onChange={(event) => {
-            setUrl(event.target.value);
-            setSubmission(null);
-          }}
-          autoComplete="off"
-          spellCheck={false}
-        />
-        <p className={styles.helper}>
-          We only parse the link locally. The import request is sent once you confirm.
-        </p>
+    <div className={styles.formWrapper}>
+      <div className={styles.tabList} role="tablist" aria-label="Import mode">
+        <button
+          type="button"
+          id={singleTabId}
+          className={singleTabClassName}
+          role="tab"
+          aria-selected={activeTab === 'single'}
+          aria-controls={singlePanelId}
+          onClick={handleSelectSingle}
+        >
+          Single link
+        </button>
+        <button
+          type="button"
+          id={bulkTabId}
+          className={bulkTabClassName}
+          role="tab"
+          aria-selected={activeTab === 'bulk'}
+          aria-controls={bulkPanelId}
+          onClick={handleSelectBulk}
+        >
+          Bulk import
+        </button>
       </div>
-      {renderPreview()}
-      {submission ? (
-        <div className={styles.responsePanel}>
-          <h3 className={styles.responseTitle}>
-            {submission.status === 'success' ? 'Import queued' : 'Import failed'}
-          </h3>
-          {'requestId' in submission && submission.requestId ? (
-            <p className={styles.responseMeta}>Request ID: {submission.requestId}</p>
+      {activeTab === 'single' ? (
+        <form
+          className={styles.form}
+          onSubmit={handleSubmit}
+          id={singlePanelId}
+          role="tabpanel"
+          aria-labelledby={singleTabId}
+        >
+          {enableWizard ? (
+            <section className={styles.wizardSection}>
+              <div className={styles.wizardHeader}>
+                <p className={styles.wizardTitle}>Need help finding the JSON link?</p>
+                <button
+                  type="button"
+                  className={styles.wizardToggle}
+                  onClick={() => setWizardOpen((previous) => !previous)}
+                  aria-expanded={wizardOpen}
+                >
+                  {wizardOpen ? 'Hide wizard' : 'Open wizard'}
+                </button>
+              </div>
+              {wizardOpen ? (
+                <Wizard
+                  onComplete={(wizardUrl) => {
+                    setUrl(wizardUrl);
+                    setSubmission(null);
+                    setWizardOpen(false);
+                  }}
+                />
+              ) : null}
+            </section>
           ) : null}
-          {submission.status === 'success' ? (
-            <pre className={styles.responsePre}>{JSON.stringify(submission.summary, null, 2)}</pre>
-          ) : (
-            <pre className={styles.responsePre}>{formatError(submission.error)}</pre>
-          )}
-        </div>
-      ) : null}
+          <div className={styles.inputGroup}>
+            <label className={styles.label} htmlFor="liverc-url">
+              LiveRC link
+            </label>
+            <input
+              id="liverc-url"
+              name="liverc-url"
+              className={styles.input}
+              placeholder="Paste a LiveRC link (page or .json)"
+              value={url}
+              onChange={(event) => {
+                setUrl(event.target.value);
+                setSubmission(null);
+              }}
+              autoComplete="off"
+              spellCheck={false}
+            />
+            <p className={styles.helper}>
+              We only parse the link locally. The import request is sent once you confirm.
+            </p>
+          </div>
+          {renderPreview()}
+          {submission ? (
+            <div className={styles.responsePanel}>
+              <h3 className={styles.responseTitle}>
+                {submission.status === 'success' ? 'Import queued' : 'Import failed'}
+              </h3>
+              {'requestId' in submission && submission.requestId ? (
+                <p className={styles.responseMeta}>Request ID: {submission.requestId}</p>
+              ) : null}
+              {submission.status === 'success' ? (
+                <pre className={styles.responsePre}>
+                  {JSON.stringify(submission.summary, null, 2)}
+                </pre>
+              ) : (
+                <pre className={styles.responsePre}>{formatError(submission.error)}</pre>
+              )}
+            </div>
+          ) : null}
+        </form>
+      ) : (
+        <BulkImportTab tabPanelId={bulkPanelId} labelledById={bulkTabId} />
+      )}
       {resolverEnabled && resolveModalOpen ? (
         <div className={styles.modalBackdrop} role="presentation">
           <div
@@ -470,6 +910,6 @@ export default function ImportForm({ enableWizard = false, initialUrl }: ImportF
           </div>
         </div>
       ) : null}
-    </form>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a tabbed import experience that lets users switch between single-link and bulk LiveRC imports
- implement a bulk importer that parses pasted links, surfaces readiness in a table, and queues sequential API requests
- style the new tab controls and bulk status table to match the dashboard design system

## Testing
- npm run lint *(fails: existing lint violations in untouched files such as src/core/liverc/urlParser.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68df63f8761883219c3078f1475b8851