### PR TITLE
fix: derive LiveRC race result response type from mapper

### DIFF
--- a/src/app/(dashboard)/import/ImportForm.tsx
+++ b/src/app/(dashboard)/import/ImportForm.tsx
@@ -22,8 +22,10 @@ import {
 import type { LiveRcImportSummary } from '@core/app/services/importLiveRc';
 import {
   parseRaceResultPayload,
-  type LiveRcRaceResultResponse,
+  mapRaceResultResponse,
 } from '@core/app/liverc/responseMappers';
+
+type LiveRcRaceResultResponse = ReturnType<typeof mapRaceResultResponse>;
 
 import styles from './ImportForm.module.css';
 import Wizard from './Wizard';


### PR DESCRIPTION
## Summary
- replace the invalid LiveRcRaceResultResponse type import with mapRaceResultResponse
- define LiveRcRaceResultResponse locally using the return type of mapRaceResultResponse to preserve usage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfa675256083218aa1ac6c3f4393af