### PR TITLE
Refactor LiveRC import form type usage

### DIFF
--- a/src/app/(dashboard)/import/ImportForm.tsx
+++ b/src/app/(dashboard)/import/ImportForm.tsx
@@ -20,10 +20,7 @@ import {
   parseLiveRcUrl,
 } from '@core/app/services/liveRcUrlParser';
 import type { LiveRcImportSummary } from '@core/app/services/importLiveRc';
-import {
-  parseRaceResultPayload,
-  mapRaceResultResponse,
-} from '@core/app/liverc/responseMappers';
+import { mapRaceResultResponse, parseRaceResultPayload } from '@core/app/liverc/responseMappers';
 
 type LiveRcRaceResultResponse = ReturnType<typeof mapRaceResultResponse>;
 

--- a/src/core/app/liverc/responseMappers.ts
+++ b/src/core/app/liverc/responseMappers.ts
@@ -6,8 +6,6 @@ import type {
   LiveRcRaceResultResponse,
 } from '../ports/liveRcClient';
 
-export type { LiveRcRaceResultResponse } from '../ports/liveRcClient';
-
 const asObject = (value: unknown): Record<string, unknown> =>
   value && typeof value === 'object' ? (value as Record<string, unknown>) : {};
 


### PR DESCRIPTION
## Summary
- derive the LiveRC race result type in the dashboard import form from `mapRaceResultResponse`
- stop re-exporting `LiveRcRaceResultResponse` from the LiveRC response mappers to prevent accidental named imports

## Testing
- APP_URL=http://localhost CI=1 npm run build *(fails: existing opengraph-image prerender gradient error)*
- npm run typecheck


------
https://chatgpt.com/codex/tasks/task_e_68dfa8be67a48321a7a59fb9aefdc7b0