### PR TITLE
Fix Open Graph image rgb syntax

### DIFF
--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -7,10 +7,10 @@ export const size = {
 
 export const contentType = 'image/png';
 
-const BACKGROUND = 'linear-gradient(135deg, rgb(11 14 20) 0%, rgb(20 24 32) 100%)';
-const ACCENT = 'rgb(110 231 183)';
-const TEXT_PRIMARY = 'rgb(230 230 230)';
-const TEXT_SECONDARY = 'rgb(185 185 185)';
+const BACKGROUND = 'linear-gradient(135deg, rgb(11, 14, 20) 0%, rgb(20, 24, 32) 100%)';
+const ACCENT = 'rgb(110, 231, 183)';
+const TEXT_PRIMARY = 'rgb(230, 230, 230)';
+const TEXT_SECONDARY = 'rgb(185, 185, 185)';
 
 export default function OpengraphImage() {
   return new ImageResponse(


### PR DESCRIPTION
## Summary
- update rgb() usages in the Open Graph image to use comma-separated channel syntax so Satori parses the styles correctly
- ensure the background linear gradient definition retains proper comma separators between color stops

## Testing
- `CI=1 npm run build` *(fails: APP_URL environment variable must be defined to generate absolute URLs)*

------
https://chatgpt.com/codex/tasks/task_e_68dfadb14f1883218998c944b6c1a4cd