### PR TITLE
Fix LiveRC URL parsing for nested results paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "prettier": "^3.3.3",
         "prisma": "^5.20.0",
         "tsx": "^4.16.2",
-        "typescript": "^5.5.4"
+        "typescript": "~5.5.4"
       },
       "engines": {
         "node": ">=20.0.0",
@@ -5953,9 +5953,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "prisma": "^5.20.0",
     "prettier": "^3.3.3",
     "tsx": "^4.16.2",
-    "typescript": "^5.5.4"
+    "typescript": "~5.5.4"
   },
   "engines": {
     "node": ">=20.0.0",

--- a/src/core/liverc/urlParser.ts
+++ b/src/core/liverc/urlParser.ts
@@ -114,11 +114,14 @@ export const parseLiveRcUrl = (input: string): LiveRcUrlParseResult => {
   }
 
   const slugs = normalisedSlugs as [string, string, string, string];
-  const canonicalJsonPath = `/results/${slugs
-    .map((slug, index) => (index === slugs.length - 1 ? `${slug}.json` : slug))
-    .join('/')}`;
+  const baseSegments = pathSegments.slice(0, resultsIndex + 1);
+  const canonicalSegments = baseSegments.concat(
+    slugs.map((slug, index) => (index === slugs.length - 1 ? `${slug}.json` : slug)),
+  );
 
-  const resultsBaseUrl = `${parsedUrl.origin}/results`;
+  const canonicalJsonPath = `/${canonicalSegments.join('/')}`;
+
+  const resultsBaseUrl = `${parsedUrl.origin}/${baseSegments.join('/')}`.replace(/\/+$/, '');
 
   return {
     type: 'json',

--- a/tests/parse-live-rc-url.test.ts
+++ b/tests/parse-live-rc-url.test.ts
@@ -1,0 +1,35 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { parseLiveRcUrl } from '../src/core/liverc/urlParser';
+
+test('parseLiveRcUrl preserves nested base paths for JSON endpoints', () => {
+  const result = parseLiveRcUrl(
+    'https://example.com/prefix/results/event-1/class-a/round-2/race-3.json',
+  );
+
+  assert.equal(result.type, 'json');
+  if (result.type !== 'json') {
+    return;
+  }
+
+  assert.equal(result.resultsBaseUrl, 'https://example.com/prefix/results');
+  assert.equal(
+    result.canonicalJsonPath,
+    '/prefix/results/event-1/class-a/round-2/race-3.json',
+  );
+  assert.deepEqual(result.slugs, ['event-1', 'class-a', 'round-2', 'race-3']);
+});
+
+test('parseLiveRcUrl normalises canonical JSON paths without nested prefixes', () => {
+  const result = parseLiveRcUrl('https://example.com/results/event/class/round/race');
+
+  assert.equal(result.type, 'json');
+  if (result.type !== 'json') {
+    return;
+  }
+
+  assert.equal(result.resultsBaseUrl, 'https://example.com/results');
+  assert.equal(result.canonicalJsonPath, '/results/event/class/round/race.json');
+  assert.deepEqual(result.slugs, ['event', 'class', 'round', 'race']);
+});


### PR DESCRIPTION
## Summary
- ensure `parseLiveRcUrl` keeps any nested `/results` prefix when building canonical URLs and base paths
- add regression tests around LiveRC URL parsing for nested and standard endpoints
- pin TypeScript to 5.5.x so linting uses a supported compiler version

## Testing
- npm run lint
- npm run typecheck
- npx tsx --test tests/parse-live-rc-url.test.ts
- npx tsx --test tests/importLiveRc.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dfbf97266083219032997e64627ee9