### PR TITLE
Add hero sign-in CTA to marketing page

### DIFF
--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -28,6 +28,46 @@
   font-size: 1.125rem;
 }
 
+.heroActions {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 0.75rem;
+}
+
+.heroCta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.75rem;
+  background: var(--color-accent);
+  color: var(--color-bg);
+  border-radius: 9999px;
+  font-weight: 600;
+  font-size: 1rem;
+  text-decoration: none;
+  box-shadow: var(--shadow-elevated);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.heroCta:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-elevated-strong);
+}
+
+.heroCta:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-elevated-strong);
+  outline: 3px solid var(--color-accent);
+  outline-offset: 3px;
+}
+
+.heroCta:active {
+  transform: translateY(0);
+  box-shadow: var(--shadow-elevated);
+}
+
 .cards {
   display: flex;
   justify-content: center;
@@ -45,5 +85,13 @@
 
   .heroDescription {
     font-size: 1rem;
+  }
+
+  .heroActions {
+    width: 100%;
+  }
+
+  .heroCta {
+    width: min(100%, 18rem);
   }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import type { Metadata } from 'next';
 import Script from 'next/script';
 
@@ -72,6 +73,10 @@ export default async function Home() {
         name: 'Home',
         path: '/',
       },
+      {
+        name: 'Sign in',
+        path: '/auth/login',
+      },
     ]),
   ];
 
@@ -86,6 +91,11 @@ export default async function Home() {
       <header className={styles.heroHeader}>
         <h1 className={styles.heroTitle}>My Race Engineer (MRE)</h1>
         <p className={styles.heroDescription}>{PAGE_DESCRIPTION}</p>
+        <div className={styles.heroActions}>
+          <Link className={styles.heroCta} href="/auth/login">
+            Sign in to your telemetry
+          </Link>
+        </div>
       </header>
       <div className={styles.cards}>
         <LapSummaryCard summary={summary} />


### PR DESCRIPTION
## Summary
- add a prominent hero call-to-action on the home page that links directly to /auth/login and update the structured navigation data
- style the new sign-in button with existing design tokens so it remains consistent and responsive across breakpoints

## Testing
- npm run lint
- npm run dev # manually verified the home page CTA renders and routes to /auth/login


------
https://chatgpt.com/codex/tasks/task_e_68e091cda8fc832184592bb1bfafb09d