### PR TITLE
Handle missing session secret for auth forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ Dev server listens on `http://localhost:3001/` (also `http://0.0.0.0:3001/`).
 | `NEXT_PUBLIC_ENV` | `development` / `production` (UI only) |
 | `NEXT_PUBLIC_BASE_URL` | Same as `APP_URL` for client code |
 
+> ⚠️ Authentication forms are disabled when `SESSION_SECRET` is missing or shorter than 32 characters. Always set a strong value in production so registration, sign-in, and password reset flows function correctly.
+
 ---
 
 ## Scripts

--- a/src/app/(auth)/auth/auth.module.css
+++ b/src/app/(auth)/auth/auth.module.css
@@ -64,6 +64,11 @@
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
+.input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .input:focus-visible {
   outline: 3px solid var(--color-accent);
   outline-offset: 3px;
@@ -86,6 +91,11 @@
   width: 1.1rem;
   height: 1.1rem;
   accent-color: var(--color-accent);
+}
+
+.checkbox:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .helpText {
@@ -127,6 +137,13 @@
 .primaryButton:hover {
   transform: translateY(-1px);
   box-shadow: var(--shadow-elevated-strong);
+}
+
+.primaryButton:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+  box-shadow: none;
 }
 
 .primaryButton:focus-visible {


### PR DESCRIPTION
## Summary
- ensure auth form token generation throws in production when SESSION_SECRET is unset or too short and document the requirement
- surface configuration error messaging across registration, login, and password reset pages while disabling submission controls
- add disabled state styling for auth inputs/buttons and improve registration submit logging when unexpected errors occur

## Testing
- npm run lint *(fails: existing lint errors in legacy infra/auth files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2438f24dc83218e654605458c2003