### PR TITLE
chore: disable file logging during Next.js build phase

### DIFF
--- a/src/dependencies/logger.ts
+++ b/src/dependencies/logger.ts
@@ -1,11 +1,13 @@
 import type { Logger, LoggerContext } from '@core/app';
 import { createPinoLogger } from '@core/infra';
 
-const disableFileLogs = process.env.DISABLE_FILE_LOGS === 'true';
+const isBuildPhase = process.env.NEXT_PHASE === 'phase-production-build';
+const disableFileLogs = isBuildPhase || process.env.DISABLE_FILE_LOGS === 'true';
 
 export const applicationLogger: Logger = createPinoLogger({
-  level: process.env.LOG_LEVEL,
+  logDirectory: process.env.LOG_DIR || './_logs',
   disableFileLogs,
+  level: process.env.LOG_LEVEL ?? 'info',
 });
 
 export const getRequestLogger = (context: LoggerContext): Logger =>


### PR DESCRIPTION
## Summary
- guard the Pino logger so file logging is always disabled during the Next.js production build
- provide explicit defaults for log directory and log level via environment variables

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e252ba1bc08321a2207da239510a31