### PR TITLE
chore: externalize pino transports in Next config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,7 @@ const nextConfig = {
   reactStrictMode: true,
   experimental: {
     typedRoutes: true,
+    serverComponentsExternalPackages: ['pino', 'pino-pretty', 'thread-stream', 'pino-abstract-transport'],
   },
   eslint: {
     dirs: ['src'],
@@ -14,6 +15,18 @@ const nextConfig = {
     TZ: process.env.TZ ?? 'Australia/Sydney',
     ENABLE_LIVERC_RESOLVER: process.env.ENABLE_LIVERC_RESOLVER,
     LIVERC_HTTP_BASE: process.env.LIVERC_HTTP_BASE,
+  },
+  webpack: (config, { isServer }) => {
+    if (isServer) {
+      config.externals = config.externals || [];
+      config.externals.push({
+        'pino-pretty': 'commonjs pino-pretty',
+        'thread-stream': 'commonjs thread-stream',
+        'pino-abstract-transport': 'commonjs pino-abstract-transport',
+      });
+    }
+
+    return config;
   },
   poweredByHeader: false,
   async redirects() {


### PR DESCRIPTION
## Summary
- allow Next.js server components to treat the pino logger and its transports as external packages
- configure the server webpack build to externalize pino transport dependencies

## Testing
- npm run build *(fails: Module not found: Can't resolve 'pino' / 'argon2')*

------
https://chatgpt.com/codex/tasks/task_e_68e25f8fa0b48321b9578055dcb3bc01