### PR TITLE
Clarify owner name in guardrail exception

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@
 ## 1) Branching & workflow
 - **Branch per change** (feature, fix, docs, chore). Short-lived; always via PR to `main`.
 - **Small, single-purpose diffs.** Split if >~300 LOC or mixing concerns.
+  - **Exception (owner-authorized only):** When the repo owner, Jayson, explicitly authorizes a larger or multi-purpose change (and the PR summary documents that approval), contributors may follow that directive for the scope of the request. No other exceptions are permitted.
 
 ### 1.1 Branch naming (adopted)
 **Format:** `<type>/<ticket?>-<short-kebab-summary>`  


### PR DESCRIPTION
## Summary
- specify that only the repo owner, Jayson, can authorize larger or multi-purpose diffs under the documented exception

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e396ae8b2c8321b685189891b1e4f3