### PR TITLE
Add runtime cookie security helper and origin guard

### DIFF
--- a/src/server/runtime.ts
+++ b/src/server/runtime.ts
@@ -1,0 +1,46 @@
+const normalizeTrailingSlash = (value: string) => {
+  let normalized = value;
+
+  while (normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1);
+  }
+
+  return normalized;
+};
+
+export const getAppUrl = (): URL => {
+  const raw = process.env.APP_URL?.trim();
+
+  if (!raw) {
+    throw new Error('APP_URL is not configured');
+  }
+
+  try {
+    return new URL(raw);
+  } catch {
+    throw new Error('APP_URL is invalid');
+  }
+};
+
+export const isCookieSecure = (): boolean => {
+  if (process.env.COOKIE_SECURE === 'true') {
+    return true;
+  }
+
+  return getAppUrl().protocol === 'https:';
+};
+
+export const getAllowedOrigins = (): string[] => {
+  const raw = process.env.ALLOWED_ORIGINS;
+
+  if (!raw) {
+    return [];
+  }
+
+  return raw
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean)
+    .map((value) => normalizeTrailingSlash(value).toLowerCase())
+    .filter(Boolean);
+};

--- a/src/server/security/origin.ts
+++ b/src/server/security/origin.ts
@@ -1,0 +1,68 @@
+import type { Logger } from '@core/app';
+
+import { applicationLogger } from '@/dependencies/logger';
+
+import { getAllowedOrigins } from '../runtime';
+
+type HeaderGetter = Pick<Headers, 'get'>;
+
+export type OriginValidationResult = 'ok' | 'missing' | 'mismatch';
+
+const normalizeOriginValue = (value: string): string | null => {
+  try {
+    const parsed = new URL(value);
+    return parsed.origin.toLowerCase();
+  } catch {
+    return null;
+  }
+};
+
+export const validateOrigin = (headers: HeaderGetter): OriginValidationResult => {
+  const allowedOrigins = getAllowedOrigins();
+  const originHeader = headers.get('origin')?.trim();
+
+  if (originHeader) {
+    const normalizedOrigin = normalizeOriginValue(originHeader);
+
+    if (!normalizedOrigin) {
+      return 'mismatch';
+    }
+
+    return allowedOrigins.includes(normalizedOrigin) ? 'ok' : 'mismatch';
+  }
+
+  const refererHeader = headers.get('referer')?.trim();
+
+  if (!refererHeader) {
+    return 'missing';
+  }
+
+  const normalizedReferer = normalizeOriginValue(refererHeader);
+
+  if (!normalizedReferer) {
+    return 'mismatch';
+  }
+
+  return allowedOrigins.includes(normalizedReferer) ? 'ok' : 'mismatch';
+};
+
+export const guardAuthPostOrigin = (
+  headers: HeaderGetter,
+  onFailure: () => never,
+  options?: { logger?: Logger; route?: string },
+): void => {
+  const result = validateOrigin(headers);
+
+  if (result === 'ok') {
+    return;
+  }
+
+  const logger = options?.logger ?? applicationLogger;
+
+  logger.warn('auth.post_origin_denied', {
+    route: options?.route,
+    reason: `origin_${result}`,
+  });
+
+  onFailure();
+};

--- a/tests/origin.test.ts
+++ b/tests/origin.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { validateOrigin } from '../src/server/security/origin';
+
+const originalAllowedOrigins = process.env.ALLOWED_ORIGINS;
+
+const restoreEnv = () => {
+  if (originalAllowedOrigins === undefined) {
+    delete process.env.ALLOWED_ORIGINS;
+  } else {
+    process.env.ALLOWED_ORIGINS = originalAllowedOrigins;
+  }
+};
+
+test.afterEach(() => {
+  restoreEnv();
+});
+
+test('validateOrigin accepts requests that match the configured origin', () => {
+  process.env.ALLOWED_ORIGINS = 'https://example.com';
+  const headers = new Headers({
+    origin: 'https://example.com',
+  });
+
+  assert.equal(validateOrigin(headers), 'ok');
+});
+
+test('validateOrigin falls back to referer when origin is missing', () => {
+  process.env.ALLOWED_ORIGINS = 'https://example.com';
+  const headers = new Headers({
+    referer: 'https://example.com/path',
+  });
+
+  assert.equal(validateOrigin(headers), 'ok');
+});
+
+test('validateOrigin returns mismatch for unexpected origins', () => {
+  process.env.ALLOWED_ORIGINS = 'https://example.com';
+  const headers = new Headers({
+    origin: 'https://attacker.com',
+  });
+
+  assert.equal(validateOrigin(headers), 'mismatch');
+});
+
+test('validateOrigin reports missing when no headers are present', () => {
+  process.env.ALLOWED_ORIGINS = 'https://example.com';
+  const headers = new Headers();
+
+  assert.equal(validateOrigin(headers), 'missing');
+});

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getAllowedOrigins, isCookieSecure } from '../src/server/runtime';
+
+const originalAppUrl = process.env.APP_URL;
+const originalCookieSecure = process.env.COOKIE_SECURE;
+const originalAllowedOrigins = process.env.ALLOWED_ORIGINS;
+
+const restoreEnv = () => {
+  if (originalAppUrl === undefined) {
+    delete process.env.APP_URL;
+  } else {
+    process.env.APP_URL = originalAppUrl;
+  }
+
+  if (originalCookieSecure === undefined) {
+    delete process.env.COOKIE_SECURE;
+  } else {
+    process.env.COOKIE_SECURE = originalCookieSecure;
+  }
+
+  if (originalAllowedOrigins === undefined) {
+    delete process.env.ALLOWED_ORIGINS;
+  } else {
+    process.env.ALLOWED_ORIGINS = originalAllowedOrigins;
+  }
+};
+
+test.afterEach(() => {
+  restoreEnv();
+});
+
+test('isCookieSecure returns false for http app URLs by default', () => {
+  process.env.APP_URL = 'http://localhost:3001';
+  delete process.env.COOKIE_SECURE;
+
+  assert.equal(isCookieSecure(), false);
+});
+
+test('isCookieSecure prefers explicit env override', () => {
+  process.env.APP_URL = 'http://localhost:3001';
+  process.env.COOKIE_SECURE = 'true';
+
+  assert.equal(isCookieSecure(), true);
+});
+
+test('isCookieSecure returns true when APP_URL is https', () => {
+  process.env.APP_URL = 'https://example.com';
+  delete process.env.COOKIE_SECURE;
+
+  assert.equal(isCookieSecure(), true);
+});
+
+test('getAllowedOrigins trims entries and removes trailing slashes', () => {
+  process.env.ALLOWED_ORIGINS = ' https://example.com/ ,http://localhost:3001/,https://EXAMPLE.com ';
+
+  assert.deepEqual(getAllowedOrigins(), [
+    'https://example.com',
+    'http://localhost:3001',
+    'https://example.com',
+  ]);
+});


### PR DESCRIPTION
## Summary
- add runtime helpers for app URL parsing, cookie security, and allowed origins
- guard auth server actions with centralized origin validation and reuse secure cookie flag
- cover cookie/origin helpers with node:test unit tests

## Testing
- npx tsx --test tests/seo.test.ts tests/runtime.test.ts tests/origin.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e47316a94883218c47bbc6e2958f74