### PR TITLE
Improve auth origin error guidance

### DIFF
--- a/src/app/(auth)/auth/login/actions.ts
+++ b/src/app/(auth)/auth/login/actions.ts
@@ -63,7 +63,7 @@ export const loginAction = async (formData: FormData) => {
     () =>
       redirect(
         buildRedirectUrl('/auth/login', {
-          error: 'invalid-token',
+          error: 'invalid-origin',
         }),
       ),
     {

--- a/src/app/(auth)/auth/login/page.tsx
+++ b/src/app/(auth)/auth/login/page.tsx
@@ -97,6 +97,12 @@ const buildStatusMessage = (
   }
 
   switch (errorCode) {
+    case 'invalid-origin':
+      return {
+        tone: 'error' as const,
+        message:
+          'Sign in requests from this origin are blocked. Add the site origin to the ALLOWED_ORIGINS environment variable and try again.',
+      };
     case 'invalid-token':
       return {
         tone: 'error' as const,

--- a/src/app/(auth)/auth/register/actions.ts
+++ b/src/app/(auth)/auth/register/actions.ts
@@ -84,7 +84,7 @@ export const registerAction = async (formData: FormData) => {
     () =>
       redirect(
         buildRedirectUrl('/auth/register', {
-          error: 'invalid-token',
+          error: 'invalid-origin',
         }),
       ),
     {

--- a/src/app/(auth)/auth/register/page.tsx
+++ b/src/app/(auth)/auth/register/page.tsx
@@ -66,6 +66,12 @@ const getParam = (value: string | string[] | undefined) => {
 // for accessibility.
 const buildStatusMessage = (errorCode: string | undefined): StatusMessage => {
   switch (errorCode) {
+    case 'invalid-origin':
+      return {
+        tone: 'error' as const,
+        message:
+          'This request came from an origin that is not allowed. Update the ALLOWED_ORIGINS environment variable to include this site and refresh the page.',
+      };
     case 'invalid-token':
       return {
         tone: 'error' as const,


### PR DESCRIPTION
## Summary
- return an explicit invalid-origin error when CSRF origin validation fails for login and registration
- surface guidance on configuring ALLOWED_ORIGINS in the auth form status messages

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e48c241194832199f72918c349f01f