### PR TITLE
Fix auth POST origin guard redirects

### DIFF
--- a/docs/guardrails/auth-origin-troubleshooting.md
+++ b/docs/guardrails/auth-origin-troubleshooting.md
@@ -1,8 +1,8 @@
 # Auth form origin guard failures
 
-When every login or registration attempt immediately redirects back with the banner “Your session expired. Refresh the page and try again.”, the failure is not caused by the session layer. Instead, the post request is being rejected before it reaches the auth service because the [`guardAuthPostOrigin`](../../src/server/security/origin.ts) check determines the request originated from an unapproved host.
+When every login or registration attempt immediately redirects back with the banner “Your session expired. Refresh the page and try again.”, the failure is not caused by the session layer. Instead, the post request is being rejected before it reaches the auth service because the [`guardAuthPostOrigin`](../../src/core/auth/guardAuthPostOrigin.ts) check determines the request originated from an unapproved host.
 
-The guard delegates to [`getAllowedOrigins`](../../src/server/runtime.ts), which prioritises the comma-separated `ALLOWED_ORIGINS` environment variable. When that variable is unset or empty the helper now falls back to the origin derived from `APP_URL`, ensuring single-origin environments continue to work out of the box. If neither source matches the exact origin (scheme + host + optional port) that the browser is using, the guard resolves to `mismatch`, triggering the early redirect with the generic “session expired” messaging that the forms historically displayed.
+The guard delegates to [`getAllowedOrigins`](../../src/core/auth/getAllowedOrigins.ts), which prioritises the comma-separated `ALLOWED_ORIGINS` environment variable. When that variable is unset or empty the helper now falls back to the origin derived from `APP_URL`, ensuring single-origin environments continue to work out of the box. If neither source matches the exact origin (scheme + host + optional port) that the browser is using, the guard resolves to `mismatch`, triggering the early redirect with the generic “session expired” messaging that the forms historically displayed.
 
 ## How to fix
 1. Confirm which domains should be allowed to submit authentication forms.

--- a/src/app/(auth)/auth/login/(guard)/route.ts
+++ b/src/app/(auth)/auth/login/(guard)/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+
+import { guardAuthPostOrigin } from '@/core/auth/guardAuthPostOrigin';
+
+import { loginAction } from '../actions';
+
+export async function POST(req: Request): Promise<Response> {
+  const bounce = guardAuthPostOrigin(req, '/auth/login');
+  if (bounce) {
+    return bounce;
+  }
+
+  const formData = await req.formData();
+  await loginAction(formData);
+
+  return NextResponse.redirect(new URL('/auth/login', req.url), { status: 303 });
+}

--- a/src/app/(auth)/auth/register/(guard)/route.ts
+++ b/src/app/(auth)/auth/register/(guard)/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+
+import { guardAuthPostOrigin } from '@/core/auth/guardAuthPostOrigin';
+
+import { registerAction } from '../actions';
+
+export async function POST(req: Request): Promise<Response> {
+  const bounce = guardAuthPostOrigin(req, '/auth/register');
+  if (bounce) {
+    return bounce;
+  }
+
+  const formData = await req.formData();
+  await registerAction(formData);
+
+  return NextResponse.redirect(new URL('/auth/register', req.url), { status: 303 });
+}

--- a/src/core/auth/getAllowedOrigins.ts
+++ b/src/core/auth/getAllowedOrigins.ts
@@ -1,0 +1,48 @@
+const normalizeTrailingSlash = (value: string): string => {
+  let normalized = value;
+
+  while (normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1);
+  }
+
+  return normalized;
+};
+
+const normalizeOrigin = (value: string | null | undefined): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const trimmed = normalizeTrailingSlash(value.trim());
+    if (!trimmed) {
+      return null;
+    }
+
+    return new URL(trimmed).origin.toLowerCase();
+  } catch {
+    return null;
+  }
+};
+
+export const getAllowedOrigins = (): Set<string> => {
+  const allowed = new Set<string>();
+
+  const raw = process.env.ALLOWED_ORIGINS;
+  if (raw) {
+    raw
+      .split(',')
+      .map((entry) => normalizeOrigin(entry))
+      .filter((origin): origin is string => Boolean(origin))
+      .forEach((origin) => allowed.add(origin));
+  }
+
+  if (allowed.size === 0) {
+    const fallback = normalizeOrigin(process.env.APP_URL);
+    if (fallback) {
+      allowed.add(fallback);
+    }
+  }
+
+  return allowed;
+};

--- a/src/core/auth/guardAuthPostOrigin.ts
+++ b/src/core/auth/guardAuthPostOrigin.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+
+import { getAllowedOrigins } from './getAllowedOrigins';
+
+type AuthRedirectPath = '/auth/login' | '/auth/register';
+
+const normalizeHeaderOrigin = (value: string | null): string | null => {
+  if (!value) {
+    return null;
+  }
+
+  const trimmed = value.trim().replace(/\/$/, '');
+
+  try {
+    return new URL(trimmed).origin.toLowerCase();
+  } catch {
+    return null;
+  }
+};
+
+export const guardAuthPostOrigin = (req: Request, redirectToPath: AuthRedirectPath) => {
+  const allowedOrigins = getAllowedOrigins();
+  const headerOrigin = normalizeHeaderOrigin(req.headers.get('origin'));
+
+  if (!headerOrigin || !allowedOrigins.has(headerOrigin)) {
+    const redirectUrl = new URL(`${redirectToPath}?error=invalid-origin`, req.url);
+    return NextResponse.redirect(redirectUrl, { status: 303 });
+  }
+
+  return null;
+};

--- a/src/server/runtime.ts
+++ b/src/server/runtime.ts
@@ -1,13 +1,3 @@
-const normalizeTrailingSlash = (value: string) => {
-  let normalized = value;
-
-  while (normalized.endsWith('/')) {
-    normalized = normalized.slice(0, -1);
-  }
-
-  return normalized;
-};
-
 export const getAppUrl = (): URL => {
   const raw = process.env.APP_URL?.trim();
 
@@ -28,35 +18,4 @@ export const isCookieSecure = (): boolean => {
   }
 
   return getAppUrl().protocol === 'https:';
-};
-
-const normalizeOrigin = (value: string): string | null => {
-  if (!value) {
-    return null;
-  }
-
-  try {
-    const origin = new URL(normalizeTrailingSlash(value)).origin.toLowerCase();
-    return origin;
-  } catch {
-    return null;
-  }
-};
-
-export const getAllowedOrigins = (): string[] => {
-  const raw = process.env.ALLOWED_ORIGINS;
-
-  const configuredOrigins = raw
-    ?.split(',')
-    .map((value) => normalizeOrigin(value.trim()))
-    .filter((origin): origin is string => Boolean(origin));
-
-  if (configuredOrigins && configuredOrigins.length > 0) {
-    return configuredOrigins;
-  }
-
-  const fallbackAppUrl = process.env.APP_URL?.trim();
-  const fallbackOrigin = normalizeOrigin(fallbackAppUrl ?? '');
-
-  return fallbackOrigin ? [fallbackOrigin] : [];
 };

--- a/src/server/security/origin.ts
+++ b/src/server/security/origin.ts
@@ -2,7 +2,7 @@ import type { Logger } from '@core/app';
 
 import { applicationLogger } from '@/dependencies/logger';
 
-import { getAllowedOrigins } from '../runtime';
+import { getAllowedOrigins } from '@/core/auth/getAllowedOrigins';
 
 type HeaderGetter = Pick<Headers, 'get'>;
 
@@ -28,7 +28,7 @@ export const validateOrigin = (headers: HeaderGetter): OriginValidationResult =>
       return 'mismatch';
     }
 
-    return allowedOrigins.includes(normalizedOrigin) ? 'ok' : 'mismatch';
+    return allowedOrigins.has(normalizedOrigin) ? 'ok' : 'mismatch';
   }
 
   const refererHeader = headers.get('referer')?.trim();
@@ -43,7 +43,7 @@ export const validateOrigin = (headers: HeaderGetter): OriginValidationResult =>
     return 'mismatch';
   }
 
-  return allowedOrigins.includes(normalizedReferer) ? 'ok' : 'mismatch';
+  return allowedOrigins.has(normalizedReferer) ? 'ok' : 'mismatch';
 };
 
 export const guardAuthPostOrigin = (

--- a/tests/core/auth/origin.test.ts
+++ b/tests/core/auth/origin.test.ts
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getAllowedOrigins } from '../../../src/core/auth/getAllowedOrigins';
+import { guardAuthPostOrigin } from '../../../src/core/auth/guardAuthPostOrigin';
+
+const originalAppUrl = process.env.APP_URL;
+const originalAllowedOrigins = process.env.ALLOWED_ORIGINS;
+
+const restoreEnv = () => {
+  if (originalAppUrl === undefined) {
+    delete process.env.APP_URL;
+  } else {
+    process.env.APP_URL = originalAppUrl;
+  }
+
+  if (originalAllowedOrigins === undefined) {
+    delete process.env.ALLOWED_ORIGINS;
+  } else {
+    process.env.ALLOWED_ORIGINS = originalAllowedOrigins;
+  }
+};
+
+test.afterEach(() => {
+  restoreEnv();
+});
+
+test('getAllowedOrigins normalises entries and removes duplicates', () => {
+  process.env.ALLOWED_ORIGINS = ' https://example.com/ ,http://localhost:3001/,https://EXAMPLE.com ';
+
+  const allowed = getAllowedOrigins();
+
+  assert.equal(allowed.size, 2);
+  assert(allowed.has('https://example.com'));
+  assert(allowed.has('http://localhost:3001'));
+});
+
+test('getAllowedOrigins falls back to APP_URL when explicit origins are missing', () => {
+  delete process.env.ALLOWED_ORIGINS;
+  process.env.APP_URL = 'https://example.com/app';
+
+  const allowed = getAllowedOrigins();
+
+  assert.equal(allowed.size, 1);
+  assert(allowed.has('https://example.com'));
+});
+
+test('guardAuthPostOrigin allows configured origins', () => {
+  process.env.ALLOWED_ORIGINS = 'https://example.com';
+
+  const request = new Request('https://app.local/auth/login', {
+    method: 'POST',
+    headers: {
+      origin: 'https://example.com',
+    },
+  });
+
+  const result = guardAuthPostOrigin(request, '/auth/login');
+
+  assert.equal(result, null);
+});
+
+test('guardAuthPostOrigin redirects mismatched origins', () => {
+  process.env.ALLOWED_ORIGINS = 'https://example.com';
+
+  const request = new Request('https://app.local/auth/login', {
+    method: 'POST',
+    headers: {
+      origin: 'https://evil.example',
+    },
+  });
+
+  const result = guardAuthPostOrigin(request, '/auth/login');
+
+  assert(result instanceof Response);
+  assert.equal(result.status, 303);
+  assert.equal(result.headers.get('location'), 'https://app.local/auth/login?error=invalid-origin');
+});
+
+test('guardAuthPostOrigin redirects when origin header is missing', () => {
+  process.env.ALLOWED_ORIGINS = 'https://example.com';
+
+  const request = new Request('https://app.local/auth/register', {
+    method: 'POST',
+  });
+
+  const result = guardAuthPostOrigin(request, '/auth/register');
+
+  assert(result instanceof Response);
+  assert.equal(result.status, 303);
+  assert.equal(result.headers.get('location'), 'https://app.local/auth/register?error=invalid-origin');
+});

--- a/tests/runtime.test.ts
+++ b/tests/runtime.test.ts
@@ -1,11 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { getAllowedOrigins, isCookieSecure } from '../src/server/runtime';
+import { isCookieSecure } from '../src/server/runtime';
 
 const originalAppUrl = process.env.APP_URL;
 const originalCookieSecure = process.env.COOKIE_SECURE;
-const originalAllowedOrigins = process.env.ALLOWED_ORIGINS;
 
 const restoreEnv = () => {
   if (originalAppUrl === undefined) {
@@ -20,11 +19,6 @@ const restoreEnv = () => {
     process.env.COOKIE_SECURE = originalCookieSecure;
   }
 
-  if (originalAllowedOrigins === undefined) {
-    delete process.env.ALLOWED_ORIGINS;
-  } else {
-    process.env.ALLOWED_ORIGINS = originalAllowedOrigins;
-  }
 };
 
 test.afterEach(() => {
@@ -52,19 +46,3 @@ test('isCookieSecure returns true when APP_URL is https', () => {
   assert.equal(isCookieSecure(), true);
 });
 
-test('getAllowedOrigins trims entries and removes trailing slashes', () => {
-  process.env.ALLOWED_ORIGINS = ' https://example.com/ ,http://localhost:3001/,https://EXAMPLE.com ';
-
-  assert.deepEqual(getAllowedOrigins(), [
-    'https://example.com',
-    'http://localhost:3001',
-    'https://example.com',
-  ]);
-});
-
-test('getAllowedOrigins falls back to APP_URL origin when not configured', () => {
-  delete process.env.ALLOWED_ORIGINS;
-  process.env.APP_URL = 'https://example.com/app';
-
-  assert.deepEqual(getAllowedOrigins(), ['https://example.com']);
-});


### PR DESCRIPTION
## Summary
- add a core helper that normalises configured auth origins and expose a guard returning clean 303 redirects
- apply the guard to the auth login and registration POST handlers before parsing request bodies
- cover the helper/guard with unit tests and update existing documentation references

## Testing
- npm run typecheck
- npx tsx --test tests/core/auth/origin.test.ts
- APP_URL=http://localhost:3001 CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e4fb8b861883219959aad6ffc351fb