### PR TITLE
test: fix register service unit doubles

### DIFF
--- a/docs/reviews/2025-03-18-auth-registration-deep-review.md
+++ b/docs/reviews/2025-03-18-auth-registration-deep-review.md
@@ -1,0 +1,27 @@
+# 2025-03-18 Deep Review – Account Registration
+
+## Scope & Context
+This review audits the current account registration workflow spanning the App Router form (`/auth/register`), the server action orchestration, and the `RegisterUserService` domain logic plus supporting infrastructure. The goal is to identify correctness, security, and resilience gaps that affect account creation and the subsequent onboarding steps.
+
+## Highlights
+- Strong password policy enforcement exists in both the server action schema and the domain service, preventing weak credentials before persistence or expensive work is performed.【F:src/app/(auth)/auth/register/actions.ts†L17-L53】【F:src/core/app/services/auth/registerUser.ts†L70-L116】
+- Registration outcomes map to clear next steps (verification, approval, or direct session issuance), and the UI propagates contextual messaging back to the caller via structured redirects.【F:src/app/(auth)/auth/register/actions.ts†L153-L205】
+
+## Risks & Gaps
+1. **Duplicate email race leads to 500s instead of friendly errors.** The service performs a `findByEmail` check and then calls `userRepository.create` without guarding against unique constraint violations. Concurrent requests for the same email can pass the existence check and rely on the database to reject the duplicate, which propagates as an unhandled exception and surfaces as a 500 rather than returning the documented `email-taken` result.【F:src/core/app/services/auth/registerUser.ts†L86-L117】【F:src/core/infra/prisma/prismaUserRepository.ts†L37-L66】
+2. **No transactional safety around multi-step side effects.** After inserting the user the service sends verification emails, persists tokens, and optionally issues sessions. Any failure after the user row is created (e.g. mailer outage, Prisma error) leaves the account in a partially initialised state without compensating cleanup or retries, forcing operators to intervene manually.【F:src/core/app/services/auth/registerUser.ts†L109-L208】
+3. **Session tokens persisted in plaintext.** Issued session secrets are written directly to the database and returned to the caller without hashing, which means a datastore leak immediately compromises every active session. The Prisma adapter mirrors this by storing `sessionToken` verbatim.【F:src/core/app/services/auth/registerUser.ts†L176-L208】【F:src/core/infra/prisma/prismaUserSessionRepository.ts†L21-L36】
+4. **Mixed verification + admin approval flows are ambiguous.** When both feature flags are enabled the service returns `nextStep: 'verify-email'`, never signalling that admin approval is still required after verification. Users who verify successfully will continue to see a pending account with no messaging about the remaining approval gate.【F:src/core/app/services/auth/registerUser.ts†L100-L174】
+5. **Unhandled domain faults bubble into generic error pages.** The server action assumes the domain call resolves to a success/failure result but does not catch thrown errors (e.g. database constraint violations or infrastructure outages) to translate them into the `server-error` UI state. Any unexpected fault renders the global error boundary instead of keeping the user on the registration surface.【F:src/app/(auth)/auth/register/actions.ts†L140-L206】
+
+## Recommendations
+- Wrap the user creation + follow-up side effects in a Prisma transaction and catch unique constraint errors to return `{ ok: false, reason: 'email-taken' }` consistently. Roll back the user insert when downstream dependencies fail so operators do not inherit partially configured accounts.
+- Hash session tokens (e.g. SHA-256 or bcrypt) before persistence and compare hashed values on lookup to mitigate database compromise scenarios.
+- Extend the service result to represent combined verification + approval states (e.g. `nextStep: 'verify-email-await-approval'`) and update the UI messaging so users understand both required actions.
+- Add defensive error handling inside `registerAction` to trap thrown errors, log them with context, and redirect back with `error=server-error` to preserve UX while instrumentation captures the root cause.
+
+## Test Coverage & Follow-up
+- Added a targeted unit suite for `RegisterUserService` covering weak-password rejection, duplicate email handling, verification email dispatch, admin approval behaviour, and happy-path session issuance.【F:tests/core/auth/registerUserService.test.ts†L1-L216】 This suite should be integrated into continuous integration runs (e.g. `npm run test:auth`) so regressions in account creation surface quickly.
+- Automated test execution: `npx tsx --test tests/core/auth/registerUserService.test.ts`【4fd8a8†L1-L12】
+
+Addressing the highlighted risks will tighten security posture, improve error resilience, and align the onboarding UX with feature-flag combinations expected in production.

--- a/tests/core/auth/registerUserService.test.ts
+++ b/tests/core/auth/registerUserService.test.ts
@@ -1,0 +1,384 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import test from 'node:test';
+
+import type {
+  Logger,
+  LoggerContext,
+  LogLevel,
+  MailMessage,
+  MailerPort,
+  PasswordHasher,
+  UserEmailVerificationTokenRepository,
+  UserRepository,
+  UserSessionRepository,
+} from '@core/app';
+import { RegisterUserService } from '@core/app/services/auth/registerUser';
+import type {
+  CreateUserEmailVerificationTokenInput,
+  CreateUserInput,
+  CreateUserSessionInput,
+  User,
+  UserEmailVerificationToken,
+  UserSession,
+} from '@core/domain';
+
+const fixedNow = new Date('2025-01-01T00:00:00.000Z');
+const clock = () => new Date(fixedNow);
+
+class InMemoryUserRepository implements UserRepository {
+  public created: CreateUserInput | null = null;
+  public usersByEmail = new Map<string, User>();
+  public usersById = new Map<string, User>();
+
+  async findByEmail(email: string): Promise<User | null> {
+    return this.usersByEmail.get(email.toLowerCase()) ?? null;
+  }
+
+  async findById(id: string): Promise<User | null> {
+    return this.usersById.get(id) ?? null;
+  }
+
+  async create(input: CreateUserInput): Promise<User> {
+    const createdAt = clock();
+    const user: User = {
+      id: input.id,
+      name: input.name,
+      email: input.email.toLowerCase(),
+      passwordHash: input.passwordHash,
+      status: input.status,
+      emailVerifiedAt: input.emailVerifiedAt ?? null,
+      createdAt,
+      updatedAt: createdAt,
+    };
+    this.created = input;
+    this.usersByEmail.set(user.email, user);
+    this.usersById.set(user.id, user);
+    return user;
+  }
+
+  async updateEmailVerification(userId: string, verifiedAt: Date | null): Promise<User> {
+    const user = this.usersById.get(userId);
+    if (!user) throw new Error('User not found');
+    const updated: User = { ...user, emailVerifiedAt: verifiedAt, updatedAt: clock() };
+    this.usersById.set(userId, updated);
+    this.usersByEmail.set(updated.email, updated);
+    return updated;
+  }
+
+  async updateStatus(userId: string, status: User['status']): Promise<User> {
+    const user = this.usersById.get(userId);
+    if (!user) throw new Error('User not found');
+    const updated: User = { ...user, status, updatedAt: clock() };
+    this.usersById.set(userId, updated);
+    this.usersByEmail.set(updated.email, updated);
+    return updated;
+  }
+
+  async updatePasswordHash(userId: string, passwordHash: string): Promise<User> {
+    const user = this.usersById.get(userId);
+    if (!user) throw new Error('User not found');
+    const updated: User = { ...user, passwordHash, updatedAt: clock() };
+    this.usersById.set(userId, updated);
+    this.usersByEmail.set(updated.email, updated);
+    return updated;
+  }
+
+  seed(user: User) {
+    this.usersByEmail.set(user.email.toLowerCase(), user);
+    this.usersById.set(user.id, user);
+  }
+}
+
+class RecordingUserSessionRepository implements UserSessionRepository {
+  public createdSessions: CreateUserSessionInput[] = [];
+  public revokedForUser: string[] = [];
+
+  async create(input: CreateUserSessionInput): Promise<UserSession> {
+    this.createdSessions.push(input);
+    const createdAt = clock();
+    return {
+      id: input.id,
+      userId: input.userId,
+      sessionToken: input.sessionToken,
+      expiresAt: input.expiresAt,
+      ipAddress: input.ipAddress ?? null,
+      userAgent: input.userAgent ?? null,
+      deviceName: input.deviceName ?? null,
+      lastUsedAt: null,
+      revokedAt: null,
+      createdAt,
+      updatedAt: createdAt,
+    };
+  }
+
+  async revokeAllForUser(userId: string): Promise<void> {
+    this.revokedForUser.push(userId);
+  }
+}
+
+class DeterministicPasswordHasher implements PasswordHasher {
+  public hashed: string[] = [];
+
+  async hash(plainText: string): Promise<string> {
+    this.hashed.push(plainText);
+    return `hashed:${plainText}`;
+  }
+
+  async verify(hash: string, plainText: string): Promise<boolean> {
+    return hash === `hashed:${plainText}`;
+  }
+}
+
+class InMemoryVerificationTokenRepository implements UserEmailVerificationTokenRepository {
+  public tokens: UserEmailVerificationToken[] = [];
+  public deletedForUser: string[] = [];
+
+  async create(input: CreateUserEmailVerificationTokenInput): Promise<UserEmailVerificationToken> {
+    const createdAt = clock();
+    const token: UserEmailVerificationToken = {
+      id: input.id,
+      userId: input.userId,
+      tokenHash: input.tokenHash,
+      expiresAt: input.expiresAt,
+      consumedAt: null,
+      createdAt,
+      updatedAt: createdAt,
+    };
+    this.tokens.push(token);
+    return token;
+  }
+
+  async findActiveByTokenHash(tokenHash: string): Promise<UserEmailVerificationToken | null> {
+    return this.tokens.find((token) => token.tokenHash === tokenHash && token.consumedAt === null) ?? null;
+  }
+
+  async markConsumed(id: string, consumedAt: Date): Promise<UserEmailVerificationToken> {
+    const token = this.tokens.find((entry) => entry.id === id);
+    if (!token) {
+      throw new Error('Token not found');
+    }
+    token.consumedAt = consumedAt;
+    token.updatedAt = clock();
+    return token;
+  }
+
+  async deleteAllForUser(userId: string): Promise<void> {
+    this.deletedForUser.push(userId);
+    this.tokens = this.tokens.filter((token) => token.userId !== userId);
+  }
+}
+
+class RecordingMailer implements MailerPort {
+  public sent: MailMessage[] = [];
+
+  async send(message: MailMessage): Promise<void> {
+    this.sent.push(message);
+  }
+}
+
+type InMemoryLogEntry = {
+  level: LogLevel;
+  message: string;
+  context?: LoggerContext;
+};
+
+class InMemoryLogger implements Logger {
+  public entries: InMemoryLogEntry[] = [];
+
+  constructor(
+    private readonly sharedEntries: InMemoryLogEntry[] = [],
+    private readonly baseContext: LoggerContext = {},
+  ) {
+    this.entries = sharedEntries;
+  }
+
+  private record(level: LogLevel, message: string, context?: LoggerContext) {
+    const mergedContext = { ...this.baseContext, ...context };
+    this.sharedEntries.push({ level, message, context: Object.keys(mergedContext).length ? mergedContext : undefined });
+  }
+
+  debug(message: string, context?: LoggerContext): void {
+    this.record('debug', message, context);
+  }
+
+  info(message: string, context?: LoggerContext): void {
+    this.record('info', message, context);
+  }
+
+  warn(message: string, context?: LoggerContext): void {
+    this.record('warn', message, context);
+  }
+
+  error(message: string, context?: LoggerContext): void {
+    this.record('error', message, context);
+  }
+
+  withContext(context: LoggerContext): Logger {
+    return new InMemoryLogger(this.sharedEntries, { ...this.baseContext, ...context });
+  }
+}
+
+const buildService = (overrides?: {
+  repository?: InMemoryUserRepository;
+  sessionRepository?: RecordingUserSessionRepository;
+  passwordHasher?: DeterministicPasswordHasher;
+  tokenRepository?: InMemoryVerificationTokenRepository;
+  mailer?: RecordingMailer;
+  options?: Partial<ConstructorParameters<typeof RegisterUserService>[6]>;
+}) => {
+  const repository = overrides?.repository ?? new InMemoryUserRepository();
+  const sessionRepository = overrides?.sessionRepository ?? new RecordingUserSessionRepository();
+  const passwordHasher = overrides?.passwordHasher ?? new DeterministicPasswordHasher();
+  const tokenRepository = overrides?.tokenRepository ?? new InMemoryVerificationTokenRepository();
+  const mailer = overrides?.mailer ?? new RecordingMailer();
+  const logger = new InMemoryLogger();
+  const options = {
+    requireEmailVerification: false,
+    requireAdminApproval: false,
+    baseUrl: 'https://app.local',
+    ...overrides?.options,
+  };
+
+  const service = new RegisterUserService(
+    repository,
+    sessionRepository,
+    passwordHasher,
+    tokenRepository,
+    mailer,
+    logger,
+    options,
+    clock,
+  );
+
+  return { service, repository, sessionRepository, passwordHasher, tokenRepository, mailer, logger };
+};
+
+test('rejects weak passwords without touching persistence', async () => {
+  const { service, repository, passwordHasher } = buildService();
+
+  const result = await service.register({
+    name: 'Example User',
+    email: 'user@example.com',
+    password: 'short',
+  });
+
+  assert.deepEqual(result, { ok: false, reason: 'weak-password' });
+  assert.equal(repository.created, null);
+  assert.equal(passwordHasher.hashed.length, 0);
+});
+
+test('returns email-taken when repository already contains the address', async () => {
+  const { service, repository } = buildService();
+  const existingUser: User = {
+    id: 'user-1',
+    name: 'Existing User',
+    email: 'user@example.com',
+    passwordHash: 'hashed:password',
+    status: 'active',
+    emailVerifiedAt: new Date('2024-12-31T00:00:00Z'),
+    createdAt: new Date('2024-12-01T00:00:00Z'),
+    updatedAt: new Date('2024-12-01T00:00:00Z'),
+  };
+  repository.seed(existingUser);
+
+  const result = await service.register({
+    name: 'Example User',
+    email: 'user@example.com',
+    password: 'P@ssword12345',
+  });
+
+  assert.deepEqual(result, { ok: false, reason: 'email-taken' });
+});
+
+test('issues verification email and token when verification is required', async () => {
+  const { service, tokenRepository, mailer } = buildService({
+    options: { requireEmailVerification: true },
+  });
+
+  const result = await service.register({
+    name: 'Example User',
+    email: 'user@example.com',
+    password: 'P@ssword12345',
+  });
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.nextStep, 'verify-email');
+    assert.equal(result.session, undefined);
+    assert.equal(result.user.status, 'pending');
+  }
+
+  assert.equal(tokenRepository.deletedForUser.length, 1);
+  assert.equal(tokenRepository.tokens.length, 1);
+  const tokenRecord = tokenRepository.tokens[0];
+  if (result.ok) {
+    assert.equal(tokenRepository.deletedForUser[0], result.user.id);
+  }
+  const message = mailer.sent[0];
+  assert.ok(message, 'mailer should send a verification email');
+  assert.equal(message.to.email, 'user@example.com');
+  const urlMatch = message.text.match(/https?:\/\/[\S]+/);
+  assert.ok(urlMatch, 'verification URL should be present in email body');
+  const urlText = urlMatch[0].replace(/\.$/, '');
+  const verificationUrl = new URL(urlText);
+  assert.equal(verificationUrl.origin + verificationUrl.pathname, 'https://app.local/auth/verify-email');
+  const token = verificationUrl.searchParams.get('token');
+  assert.ok(token, 'token should be present in the verification URL');
+  const hashed = createHash('sha256').update(token).digest('hex');
+  assert.equal(tokenRecord.tokenHash, hashed);
+  const expectedExpiry = new Date(fixedNow.getTime() + 24 * 60 * 60 * 1000);
+  assert.equal(tokenRecord.expiresAt.getTime(), expectedExpiry.getTime());
+});
+
+test('returns await-approval when admin approval is required', async () => {
+  const { service, tokenRepository, mailer, sessionRepository } = buildService({
+    options: { requireAdminApproval: true },
+  });
+
+  const result = await service.register({
+    name: 'Example User',
+    email: 'user@example.com',
+    password: 'P@ssword12345',
+  });
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.nextStep, 'await-approval');
+    assert.equal(result.session, undefined);
+    assert.equal(result.user.status, 'pending');
+  }
+
+  assert.equal(tokenRepository.tokens.length, 0);
+  assert.deepEqual(tokenRepository.deletedForUser, []);
+  assert.equal(mailer.sent.length, 0);
+  assert.equal(sessionRepository.createdSessions.length, 0);
+});
+
+test('creates a session when verification is not required', async () => {
+  const { service, sessionRepository, passwordHasher } = buildService();
+
+  const result = await service.register({
+    name: 'Example User',
+    email: 'user@example.com',
+    password: 'P@ssword12345',
+    rememberSession: true,
+    sessionContext: { ipAddress: '203.0.113.10', userAgent: 'jest' },
+  });
+
+  assert.equal(result.ok, true);
+  if (result.ok) {
+    assert.equal(result.nextStep, 'session-created');
+    assert.ok(result.session);
+    assert.equal(sessionRepository.createdSessions.length, 1);
+    const created = sessionRepository.createdSessions[0];
+    assert.equal(created.userId, result.user.id);
+    assert.equal(created.ipAddress, '203.0.113.10');
+    const expectedExpiry = new Date(fixedNow.getTime() + 30 * 24 * 60 * 60 * 1000);
+    assert.equal(created.expiresAt.getTime(), expectedExpiry.getTime());
+    assert.equal(result.session?.expiresAt.getTime(), expectedExpiry.getTime());
+    assert.ok(result.session?.token);
+  }
+
+  assert.deepEqual(passwordHasher.hashed, ['P@ssword12345']);
+});


### PR DESCRIPTION
## Summary
- align the register service unit test doubles with the auth port contracts to stop typecheck regressions
- strengthen verification flow assertions to capture the expected recipients and cleanup behaviour

## Design / UX
- not applicable; backend-only change

## Testing
- npx tsx --test tests/core/auth/registerUserService.test.ts
- npm run typecheck

## Performance
- no impact; test-only adjustments

## Migrations / Configuration / Rollout
- no database or configuration changes required

## Telemetry
- no telemetry changes

## Risk & Rollback
- low risk; revert this commit if issues arise


------
https://chatgpt.com/codex/tasks/task_e_68e5ce0838308321bafe891b4964c57e