### PR TITLE
Add defensive logging for registration failures

### DIFF
--- a/src/lib/logging/fingerprint.ts
+++ b/src/lib/logging/fingerprint.ts
@@ -1,0 +1,13 @@
+import { createHash } from 'node:crypto';
+
+/**
+ * Produces a deterministic fingerprint suitable for logging sensitive values
+ * without storing the original PII.
+ */
+export const createLogFingerprint = (value: string | null | undefined): string | undefined => {
+  if (!value) {
+    return undefined;
+  }
+
+  return createHash('sha256').update(value).digest('hex');
+};


### PR DESCRIPTION
## Summary
- wrap the registration server action's domain call in a try/catch to log unexpected failures with contextual fingerprints
- redirect back to the registration page with a server-error flag so the UI surfaces feedback when unexpected faults occur

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e62cb66fa883218b779c8a8732c3c5